### PR TITLE
M1c: contact picker + own TCA8418 keyboard reader

### DIFF
--- a/overlay/src/advui/AdvDisplay.h
+++ b/overlay/src/advui/AdvDisplay.h
@@ -23,7 +23,9 @@ class AdvDisplay : public lgfx::LGFX_Device
     {
         {
             auto cfg = _bus.config();
-            cfg.spi_host = SPI2_HOST;
+            // Dedicated bus on SPI3/HSPI. The LoRa radio owns SPI2/FSPI (Arduino `SPI`),
+            // so keeping the display on its own peripheral avoids corrupting radio SPI.
+            cfg.spi_host = SPI3_HOST;
             cfg.spi_mode = 0;
             cfg.freq_write = 40000000;
             cfg.freq_read = 16000000;
@@ -51,7 +53,7 @@ class AdvDisplay : public lgfx::LGFX_Device
             cfg.invert = true;
             cfg.rgb_order = false;
             cfg.dlen_16bit = false;
-            cfg.bus_shared = true; // ST7789 shares the SPI bus with the SX1262 LoRa radio
+            cfg.bus_shared = false; // dedicated SPI3 bus, not shared with the radio
             _panel.config(cfg);
         }
         setPanel(&_panel);

--- a/overlay/src/advui/AdvKeyboard.cpp
+++ b/overlay/src/advui/AdvKeyboard.cpp
@@ -1,0 +1,214 @@
+#include "AdvKeyboard.h"
+#include "configuration.h"
+#include <Arduino.h>
+#include <Wire.h>
+
+namespace advui
+{
+
+namespace
+{
+
+using Key = TCA8418KeyboardBase::TCA8418Key;
+
+constexpr uint8_t kRows = 7;
+constexpr uint8_t kCols = 8;
+constexpr uint8_t kNumKeys = 56;
+constexpr uint32_t kMultiTapThreshold = 1500;
+
+constexpr uint8_t modifierFnKey = 2;
+constexpr uint8_t modifierFn = 0b0010;
+constexpr uint8_t modifierShiftKey = 6;
+constexpr uint8_t modifierShift = 0b0001;
+
+// Chars per key (base / shift / fn), and the modulus for cycling through them.
+// Ported verbatim from the stock CardputerKeyboard.
+const uint8_t TapMod[kNumKeys] = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+const unsigned char TapMap[kNumKeys][3] = {{'`', '~', Key::ESC},
+                                           {Key::TAB, 0x00, 0x00},
+                                           {0x00, 0x00, 0x00},
+                                           {0x00, 0x00, 0x00},
+                                           {'1', '!', 0x00},
+                                           {'q', 'Q', Key::REBOOT},
+                                           {0x00, 0x00, 0x00},
+                                           {0x00, 0x00, 0x00},
+                                           {'2', '@', 0x00},
+                                           {'w', 'W', 0x00},
+                                           {'a', 'A', 0x00},
+                                           {0x00, 0x00, 0x00},
+                                           {'3', '#', 0x00},
+                                           {'e', 'E', 0x00},
+                                           {'s', 'S', 0x00},
+                                           {'z', 'Z', 0x00},
+                                           {'4', '$', 0x00},
+                                           {'r', 'R', 0x00},
+                                           {'d', 'D', 0x00},
+                                           {'x', 'X', 0x00},
+                                           {'5', '%', 0x00},
+                                           {'t', 'T', 0x00},
+                                           {'f', 'F', 0x00},
+                                           {'c', 'C', 0x00},
+                                           {'6', '^', 0x00},
+                                           {'y', 'Y', 0x00},
+                                           {'g', 'G', Key::GPS_TOGGLE},
+                                           {'v', 'V', 0x00},
+                                           {'7', '&', 0x00},
+                                           {'u', 'U', 0x00},
+                                           {'h', 'H', 0x00},
+                                           {'b', 'B', Key::BT_TOGGLE},
+                                           {'8', '*', 0x00},
+                                           {'i', 'I', 0x00},
+                                           {'j', 'J', 0x00},
+                                           {'n', 'N', 0x00},
+                                           {'9', '(', 0x00},
+                                           {'o', 'O', 0x00},
+                                           {'k', 'K', 0x00},
+                                           {'m', 'M', Key::MUTE_TOGGLE},
+                                           {'0', ')', 0x00},
+                                           {'p', 'P', Key::SEND_PING},
+                                           {'l', 'L', 0x00},
+                                           {',', '<', Key::LEFT},
+                                           {'_', '-', 0x00},
+                                           {'[', '{', 0x00},
+                                           {';', ':', Key::UP},
+                                           {'.', '>', Key::DOWN},
+                                           {'=', '+', 0x00},
+                                           {']', '}', 0x00},
+                                           {'\'', '"', 0x00},
+                                           {'/', '?', Key::RIGHT},
+                                           {Key::BSP, 0x00, 0x00},
+                                           {'\\', '|', 0x00},
+                                           {Key::SELECT, 0x00, 0x00},
+                                           {' ', ' ', ' '}};
+
+// Register-level I2C via the shared Wire bus (already on GPIO 8/9). Using the
+// callback form of TCA8418KeyboardBase::begin() avoids re-running Wire.begin()
+// with the wrong default pins.
+uint8_t i2cRead(uint8_t dev, uint8_t reg, uint8_t *data, uint8_t len)
+{
+    Wire.beginTransmission(dev);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0)
+        return 1;
+    Wire.requestFrom((int)dev, (int)len);
+    uint8_t i = 0;
+    while (Wire.available() && i < len)
+        data[i++] = Wire.read();
+    return 0;
+}
+
+uint8_t i2cWrite(uint8_t dev, uint8_t reg, uint8_t *data, uint8_t len)
+{
+    Wire.beginTransmission(dev);
+    Wire.write(reg);
+    Wire.write(data, len);
+    return Wire.endTransmission();
+}
+
+} // namespace
+
+AdvKeyboard::AdvKeyboard() : TCA8418KeyboardBase(kRows, kCols) {}
+
+void AdvKeyboard::begin()
+{
+    Wire.begin(I2C_SDA, I2C_SCL); // keyboard bus (idempotent if the engine already did it)
+    TCA8418KeyboardBase::begin(i2cRead, i2cWrite, 0x34);
+}
+
+void AdvKeyboard::trigger()
+{
+    // Pop exactly one event from the FIFO (reading KEY_EVENT_A advances it). The
+    // caller re-triggers in a loop to drain, so keyCount always makes progress.
+    if (keyCount() == 0)
+        return;
+    uint8_t k = readRegister(TCA8418_REG_KEY_EVENT_A);
+    uint8_t key = k & 0x7F;
+    if (k & 0x80) {
+        pressed(key);
+    } else {
+        released();
+        state = Idle;
+    }
+}
+
+void AdvKeyboard::pressed(uint8_t key)
+{
+    if (state == Init || state == Busy)
+        return;
+
+    if (modifierFlag && (millis() - last_modifier_time > kMultiTapThreshold))
+        modifierFlag = 0;
+
+    int row = (key - 1) / 10;
+    int col = (key - 1) % 10;
+    if (row >= kRows || col >= kCols)
+        return;
+
+    next_key = row * kCols + col;
+    state = Held;
+
+    uint32_t now = millis();
+    tap_interval = now - last_tap;
+
+    updateModifierFlag(next_key);
+    if (isModifierKey(next_key))
+        last_modifier_time = now;
+
+    if ((int32_t)tap_interval < 0) {
+        last_tap = 0;
+        state = Busy;
+        return;
+    }
+
+    if (next_key != last_key || tap_interval > kMultiTapThreshold)
+        char_idx = 0;
+    else
+        char_idx += 1;
+
+    last_key = next_key;
+    last_tap = now;
+}
+
+void AdvKeyboard::released()
+{
+    if (state != Held)
+        return;
+
+    if (last_key < 0 || last_key >= kNumKeys) {
+        last_key = -1;
+        state = Idle;
+        return;
+    }
+
+    last_tap = millis();
+
+    // Esc + the four arrow keys always emit their navigation code (stock does this
+    // only in menuMode; we have no stock menu, so it's unconditional).
+    if (modifierFlag == 0 &&
+        (last_key == 0 || last_key == 43 || last_key == 46 || last_key == 47 || last_key == 51)) {
+        modifierFlag = modifierFn;
+    }
+
+    queueEvent(TapMap[last_key][modifierFlag % TapMod[last_key]]);
+
+    if (!isModifierKey(last_key))
+        modifierFlag = 0;
+}
+
+void AdvKeyboard::updateModifierFlag(uint8_t key)
+{
+    if (key == modifierShiftKey)
+        modifierFlag ^= modifierShift;
+    else if (key == modifierFnKey)
+        modifierFlag ^= modifierFn;
+}
+
+bool AdvKeyboard::isModifierKey(uint8_t key)
+{
+    return (key == modifierShiftKey || key == modifierFnKey);
+}
+
+} // namespace advui

--- a/overlay/src/advui/AdvKeyboard.h
+++ b/overlay/src/advui/AdvKeyboard.h
@@ -1,0 +1,37 @@
+#pragma once
+
+// Our own Cardputer keyboard reader. Extends the stock TCA8418KeyboardBase (which
+// owns all the low-level I2C: init/reset/matrix/FIFO), and ports the key map +
+// decode from the stock CardputerKeyboard — but without the InputBroker/menuMode
+// coupling. We poll it ourselves; no InputBroker, no stock keyboard thread.
+
+#include "input/TCA8418KeyboardBase.h"
+
+namespace advui
+{
+
+class AdvKeyboard : public TCA8418KeyboardBase
+{
+  public:
+    AdvKeyboard();
+    void begin();           // init the TCA8418 over the keyboard I2C bus (GPIO 8/9)
+    void trigger() override; // poll the FIFO; queues chars, read via hasEvent()/dequeueEvent()
+
+  protected:
+    void pressed(uint8_t key) override;
+    void released() override;
+
+  private:
+    void updateModifierFlag(uint8_t key);
+    bool isModifierKey(uint8_t key);
+
+    uint8_t modifierFlag = 0;
+    uint32_t last_modifier_time = 0;
+    int last_key = -1;
+    int next_key = -1;
+    uint32_t last_tap = 0;
+    uint8_t char_idx = 0;
+    uint32_t tap_interval = 0;
+};
+
+} // namespace advui

--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -2,22 +2,93 @@
 #include "PowerStatus.h"
 #include "configuration.h"
 #include "mesh/NodeDB.h"
+#include <cctype>
 #include <cstdio>
+#include <cstring>
 
 namespace advui
 {
+
+namespace
+{
+
+const char *nodeName(const meshtastic_NodeInfoLite *n)
+{
+    return n->long_name[0] ? n->long_name : n->short_name;
+}
+
+bool isFav(const meshtastic_NodeInfoLite *n)
+{
+    return n->bitfield & NODEINFO_BITFIELD_IS_FAVORITE_MASK;
+}
+
+// Case-insensitive substring match; empty needle matches everything.
+bool ciContains(const char *hay, const char *needle)
+{
+    if (!needle || !needle[0])
+        return true;
+    for (const char *p = hay; *p; ++p) {
+        const char *a = p;
+        const char *b = needle;
+        while (*a && *b && tolower((unsigned char)*a) == tolower((unsigned char)*b)) {
+            ++a;
+            ++b;
+        }
+        if (!*b)
+            return true;
+    }
+    return false;
+}
+
+void drawRow(lgfx::LGFXBase *g, const meshtastic_NodeInfoLite *n, int y, bool self)
+{
+    bool fav = isFav(n);
+    char nm[20];
+    const char *name = nodeName(n);
+    if (name[0])
+        snprintf(nm, sizeof(nm), "%s%-.17s", fav ? "*" : "", name);
+    else
+        snprintf(nm, sizeof(nm), "!%08x", (unsigned)n->num);
+
+    g->setTextColor(self ? 0xFFE0 : (fav ? 0xFD20 : 0xFFFF)); // self=yellow, fav=orange
+    g->setCursor(4, y);
+    g->print(nm);
+
+    g->setCursor(150, y);
+    g->setTextColor(0x07E0); // green
+    if (n->snr_q4)
+        g->printf("%4.1f", n->snr_q4 / 4.0f);
+    else
+        g->print("   -");
+
+    g->setCursor(202, y);
+    g->setTextColor(0x9CD3); // light blue
+    if (n->has_hops_away)
+        g->printf("%uh", n->hops_away);
+    else
+        g->print("?");
+}
+
+void drawFooter(lgfx::LGFXBase *g, const char *hint)
+{
+    g->setTextSize(1);
+    g->setTextColor(0x630c); // dim gray
+    g->setCursor(4, 126);
+    g->print(hint);
+}
+
+} // namespace
 
 AdvUI::AdvUI() : concurrency::OSThread("advui") {}
 
 void AdvUI::initHardware()
 {
-    // GPIO38 is the display power/backlight rail — steady HIGH, not PWM.
-    pinMode(38, OUTPUT);
+    pinMode(38, OUTPUT); // display power/backlight rail — steady HIGH, not PWM
     digitalWrite(38, HIGH);
 
     bool ok = display.init();
     display.setRotation(1); // landscape 240x135
-    display.fillScreen(0xF800); // brief proof-of-life
+    display.fillScreen(0x0000);
 
     canvas.setColorDepth(16);
     haveCanvas = (canvas.createSprite(display.width(), display.height()) != nullptr);
@@ -25,6 +96,8 @@ void AdvUI::initHardware()
              (int)haveCanvas);
 
     api.begin();
+    kb.begin();
+    LOG_INFO("advui: keyboard ready");
 }
 
 void AdvUI::drawNodeList()
@@ -36,7 +109,6 @@ void AdvUI::drawNodeList()
     size_t total = nodeDB ? nodeDB->getNumMeshNodes() : 0;
     uint32_t me = nodeDB ? nodeDB->getNodeNum() : 0;
 
-    // Header: node count (left), battery (right)
     g->setTextSize(1);
 
     char bbuf[10];
@@ -61,52 +133,99 @@ void AdvUI::drawNodeList()
     g->setCursor(238 - bw, 3);
     g->print(bbuf);
 
-    g->drawFastHLine(0, 13, 240, 0x39C7); // separator
+    g->drawFastHLine(0, 13, 240, 0x39C7);
 
-    const int rowH = 10;
-    const int top = 17;
-    const int maxRows = (135 - top) / rowH;
-    int y = top;
-    int shown = 0;
-
+    const int rowH = 10, top = 17, maxRows = (124 - top) / rowH; // leave a row for the footer hint
+    int y = top, shown = 0;
     for (size_t i = 0; i < total && shown < maxRows; i++) {
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNodeByIndex(i);
         if (!node)
             continue;
-
-        bool self = node->num == me;
-        const char *name = node->long_name[0] ? node->long_name : node->short_name;
-
-        char nm[18];
-        if (name[0])
-            snprintf(nm, sizeof(nm), "%-17.17s", name);
-        else
-            snprintf(nm, sizeof(nm), "!%08x", (unsigned)node->num);
-
-        g->setTextColor(self ? 0xFFE0 : 0xFFFF); // self = yellow
-        g->setCursor(4, y);
-        g->print(nm);
-
-        g->setCursor(150, y);
-        g->setTextColor(0x07E0); // green
-        if (node->snr_q4)
-            g->printf("%4.1f", node->snr_q4 / 4.0f);
-        else
-            g->print("   -");
-
-        g->setCursor(202, y);
-        g->setTextColor(0x9CD3); // light blue
-        if (node->has_hops_away)
-            g->printf("%uh", node->hops_away);
-        else
-            g->print("?");
-
+        drawRow(g, node, y, node->num == me);
         y += rowH;
         shown++;
     }
 
+    drawFooter(g, "type / ESC : find contact");
+
     if (haveCanvas)
         canvas.pushSprite(0, 0);
+}
+
+void AdvUI::drawPicker()
+{
+    lgfx::LGFXBase *g = haveCanvas ? static_cast<lgfx::LGFXBase *>(&canvas) : static_cast<lgfx::LGFXBase *>(&display);
+
+    g->fillScreen(0x0000);
+
+    // Query bar
+    g->setTextSize(1);
+    g->setTextColor(0xFFE0); // yellow
+    g->setCursor(4, 3);
+    g->printf("> %s_", query);
+    g->drawFastHLine(0, 13, 240, 0x39C7);
+
+    size_t total = nodeDB ? nodeDB->getNumMeshNodes() : 0;
+    uint32_t me = nodeDB ? nodeDB->getNodeNum() : 0;
+
+    const int rowH = 10, top = 17, maxRows = (124 - top) / rowH; // leave a row for the footer hint
+    int y = top, shown = 0;
+
+    // Pass 0: favourites, pass 1: the rest. (Recent-message senders bucket is
+    // added once incoming-message tracking lands — see M1b-3.)
+    for (int pass = 0; pass < 2 && shown < maxRows; pass++) {
+        for (size_t i = 0; i < total && shown < maxRows; i++) {
+            meshtastic_NodeInfoLite *node = nodeDB->getMeshNodeByIndex(i);
+            if (!node)
+                continue;
+            if ((pass == 0) != isFav(node))
+                continue;
+            const char *name = nodeName(node);
+            if (queryLen && !ciContains(name[0] ? name : "", query))
+                continue;
+            drawRow(g, node, y, node->num == me);
+            y += rowH;
+            shown++;
+        }
+    }
+
+    drawFooter(g, "type=filter  bksp=del  ESC=back");
+
+    if (haveCanvas)
+        canvas.pushSprite(0, 0);
+}
+
+void AdvUI::handleKey(char ch)
+{
+    unsigned char c = (unsigned char)ch;
+    bool esc = c == 0x1b;       // TCA8418Key::ESC
+    bool backspace = c == 0x08; // TCA8418Key::BSP
+    bool printable = c >= 0x20 && c < 0x7f;
+
+    if (esc) {
+        mode = (mode == MODE_PICKER) ? MODE_NODES : MODE_PICKER;
+        queryLen = 0;
+        query[0] = 0;
+        return;
+    }
+
+    // Typing in the node list opens the picker and starts filtering.
+    if (mode == MODE_NODES) {
+        if (!printable)
+            return;
+        mode = MODE_PICKER;
+        queryLen = 0;
+        query[0] = 0;
+    }
+
+    if (backspace) {
+        if (queryLen)
+            query[--queryLen] = 0;
+    } else if (printable && queryLen < sizeof(query) - 1) {
+        query[queryLen++] = c;
+        query[queryLen] = 0;
+    }
+    // Arrow/select codes (0xb4-0xb7, 0x0d) fall through unhandled for now.
 }
 
 int32_t AdvUI::runOnce()
@@ -122,8 +241,19 @@ int32_t AdvUI::runOnce()
         (void)n;
     }
 
-    drawNodeList();
-    return 200; // ~5 Hz redraw + FromRadio drain
+    kb.trigger();
+    while (kb.hasEvent()) {
+        handleKey(kb.dequeueEvent());
+        kb.trigger(); // re-read the FIFO as we drain (matches the stock poll loop)
+    }
+    kb.clearInt(); // re-arm the TCA8418 interrupt, else it stops reporting after the first event
+
+    if (mode == MODE_PICKER)
+        drawPicker();
+    else
+        drawNodeList();
+
+    return 200; // 5 Hz redraw — responsive typing, light load on the shared SPI bus
 }
 
 // Created once from an injected call in main.cpp (after setupModules); the

--- a/overlay/src/advui/AdvUI.h
+++ b/overlay/src/advui/AdvUI.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AdvDisplay.h"
+#include "AdvKeyboard.h"
 #include "InternalAPI.h"
 #include "concurrency/OSThread.h"
 #include <cstddef>
@@ -10,12 +11,13 @@ namespace advui
 {
 
 /**
- * Our own UI layer, replacing the stock graphics::Screen — additive overlay,
- * no edits to upstream files.
+ * Our own UI layer, replacing the stock graphics::Screen — additive overlay.
  *
- * Wired in via the sanctioned setupNicheGraphics() hook; runs as an OSThread so
- * the engine's scheduler drives it (no main-loop edits). Renders into an
- * off-screen sprite (double buffer) pushed to the ST7789 in one transfer.
+ * Runs as an OSThread (scheduler-driven, no main-loop edits). Two screens:
+ *  - node list (default)
+ *  - contact picker (ESC / start typing): a query bar + filtered node list.
+ * Keyboard input comes from our own AdvKeyboard (TCA8418), polled here — the
+ * stock InputBroker/keyboard is disabled.
  */
 class AdvUI : public concurrency::OSThread
 {
@@ -26,12 +28,21 @@ class AdvUI : public concurrency::OSThread
     int32_t runOnce() override;
 
   private:
+    enum Mode : uint8_t { MODE_NODES, MODE_PICKER };
+
     void initHardware();
     void drawNodeList();
+    void drawPicker();
+    void handleKey(char c);
 
     InternalAPI api;
     AdvDisplay display;
+    AdvKeyboard kb;
     lgfx::LGFX_Sprite canvas{&display}; // off-screen frame buffer
+
+    Mode mode = MODE_NODES;
+    char query[24] = {0};
+    uint8_t queryLen = 0;
 
     bool inited = false;
     bool haveCanvas = false;
@@ -39,8 +50,6 @@ class AdvUI : public concurrency::OSThread
     uint8_t fromRadioBuf[MAX_TO_FROM_RADIO_SIZE]; // sized by PhoneAPI.h
 };
 
-// Create the UI once (from an injected call in main.cpp after setupModules);
-// the OSThread base then schedules itself.
 void advuiSetup();
 
 } // namespace advui

--- a/overlay/variants/esp32s3/m5stack_cardputer_adv_advui/platformio.ini
+++ b/overlay/variants/esp32s3/m5stack_cardputer_adv_advui/platformio.ini
@@ -6,7 +6,15 @@
 extends = env:m5stack-cardputer-adv
 build_flags =
   ${env:m5stack-cardputer-adv.build_flags}
-  -D MESHTASTIC_EXCLUDE_SCREEN ; suppress the stock graphics::Screen; our OSThread UI drives the panel
+  -D MESHTASTIC_EXCLUDE_SCREEN      ; suppress the stock graphics::Screen; our OSThread UI drives the panel
+  -D MESHTASTIC_EXCLUDE_INPUTBROKER ; we read the TCA8418 keyboard ourselves (AdvKeyboard)
+; The stock keyboard files reference the now-excluded inputBroker and would fight
+; our reader for the TCA8418 FIFO — drop them from the build.
+build_src_filter =
+  ${esp32_common.build_src_filter}
+  -<input/CardputerKeyboard.cpp>
+  -<input/kbI2cBase.cpp>
+  -<input/cardKbI2cImpl.cpp>
 lib_deps =
   ${env:m5stack-cardputer-adv.lib_deps}
   lovyan03/LovyanGFX@1.2.24

--- a/scripts/sync-overlay.sh
+++ b/scripts/sync-overlay.sh
@@ -26,14 +26,4 @@ if [ -f "$MC" ] && ! grep -q 'advui-inject' "$MC"; then
   echo "injected advui hooks into main.cpp"
 fi
 
-# CardputerKeyboard.cpp (upstream) uses `inputBroker` but relies on a transitive
-# InputBroker.h include that MESHTASTIC_EXCLUDE_SCREEN removes. Inject the include
-# directly (idempotent). This is the only working-tree edit to a tracked upstream
-# file; run `git -C firmware checkout -- .` before pulling upstream, then re-sync.
-KB="$FW/src/input/CardputerKeyboard.cpp"
-if [ -f "$KB" ] && ! grep -q 'advui-inject' "$KB"; then
-  perl -0pi -e 's{#include "main\.h"\n}{#include "main.h"\n#include "InputBroker.h" // advui-inject: lost with EXCLUDE_SCREEN\n}' "$KB"
-  echo "injected InputBroker.h include into CardputerKeyboard.cpp"
-fi
-
 echo "overlay synced into $FW"


### PR DESCRIPTION
Keyboard input works on-device via our own `AdvKeyboard` (extends the stock `TCA8418KeyboardBase`, ports the Cardputer key map) — no `InputBroker`/`menuMode` coupling; the stock keyboard is disabled (`-D MESHTASTIC_EXCLUDE_INPUTBROKER` + a `build_src_filter` exclusion). ESC / typing opens a contact picker that filters the node list by name (favourites first), with on-screen hints. Also moves the display onto its own SPI3 bus (fixes LoRa SPI2 corruption). Verified on hardware: continuous input, no reboots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)