### PR TITLE
Hold-to-scroll: arrows and backspace auto-repeat while held

### DIFF
--- a/overlay/src/advui/AdvKeyboard.cpp
+++ b/overlay/src/advui/AdvKeyboard.cpp
@@ -15,7 +15,10 @@ constexpr uint8_t kRows = 7;
 constexpr uint8_t kCols = 8;
 constexpr uint8_t kNumKeys = 56;
 constexpr uint32_t kMultiTapThreshold = 1500;
-constexpr uint32_t kLongPressMs = 900; // ESC held this long -> settings, not "back"
+constexpr uint32_t kLongPressMs = 900;    // ESC held this long -> settings, not "back"
+constexpr uint32_t kRepeatDelayMs = 350;  // hold an arrow/backspace this long to start repeating
+constexpr uint32_t kRepeatEveryMs = 80;   // then repeat at this rate
+constexpr uint32_t kRepeatMaxMs = 15000;  // failsafe if the release event got lost
 
 constexpr uint8_t modifierFnKey = 2;
 constexpr uint8_t modifierFn = 0b0010;
@@ -128,6 +131,17 @@ void AdvKeyboard::trigger()
         escLongFired = true;
     }
 
+    // Auto-repeat for a held arrow / backspace (they emit on the press, see pressed()).
+    if (repeatKey >= 0) {
+        uint32_t now = millis();
+        if (now - repeatStartMs > kRepeatMaxMs) {
+            repeatKey = -1;
+        } else if ((int32_t)(now - repeatNextMs) >= 0) {
+            queueEvent(repeatChar);
+            repeatNextMs = now + kRepeatEveryMs;
+        }
+    }
+
     // Pop exactly one event from the FIFO (reading KEY_EVENT_A advances it). The
     // caller re-triggers in a loop to drain, so keyCount always makes progress.
     if (keyCount() == 0)
@@ -184,6 +198,21 @@ void AdvKeyboard::pressed(uint8_t key)
 
     last_key = next_key;
     last_tap = now;
+
+    // Arrows (nav mode) and backspace emit on the press and auto-repeat while held —
+    // that's what makes held-scrolling work. Their release is suppressed (released()).
+    bool arrow = modifierFlag == 0 && navKeys &&
+                 (next_key == 43 || next_key == 46 || next_key == 47 || next_key == 51);
+    bool bsp = modifierFlag == 0 && next_key == 52;
+    if (arrow || bsp) {
+        repeatKey = next_key;
+        repeatChar = arrow ? TapMap[next_key][2] : TapMap[next_key][0]; // [2] = the arrow code
+        repeatNextMs = now + kRepeatDelayMs;
+        repeatStartMs = now;
+        queueEvent(repeatChar);
+    } else {
+        repeatKey = -1; // any other key ends the hold-repeat
+    }
 }
 
 void AdvKeyboard::released()
@@ -209,6 +238,13 @@ void AdvKeyboard::released()
             return;
         modifierFlag = modifierFn;
         queueEvent(TapMap[0][modifierFlag % TapMod[0]]);
+        return;
+    }
+
+    // Keys of the hold-repeat family already emitted on their press — the release
+    // only stops the repeat.
+    if (repeatKey >= 0 && last_key == repeatKey) {
+        repeatKey = -1;
         return;
     }
 

--- a/overlay/src/advui/AdvKeyboard.h
+++ b/overlay/src/advui/AdvKeyboard.h
@@ -26,6 +26,10 @@ class AdvKeyboard : public TCA8418KeyboardBase
     // typing set this false so they emit their literal symbols (so '.' etc. work).
     void setNavKeys(bool on) { navKeys = on; }
 
+    // True while an auto-repeating key (arrow / backspace) is held — the UI polls
+    // faster during the hold so held-scrolling redraws smoothly.
+    bool navHeld() const { return repeatKey >= 0; }
+
   protected:
     void pressed(uint8_t key) override;
     void released() override;
@@ -45,6 +49,10 @@ class AdvKeyboard : public TCA8418KeyboardBase
     bool escDown = false;      // ESC currently held
     bool escLongFired = false; // long-press already emitted for this hold
     bool navKeys = true;       // , ; . / emit arrows (nav) vs literal symbols (typing)
+    int repeatKey = -1;         // matrix index of the held auto-repeat key (-1 = none)
+    uint8_t repeatChar = 0;     // code re-emitted while it is held
+    uint32_t repeatNextMs = 0;  // when the next auto-repeat fires
+    uint32_t repeatStartMs = 0; // failsafe: stop repeating if the release event got lost
 };
 
 } // namespace advui

--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -3807,6 +3807,8 @@ int32_t AdvUI::runOnce()
     if (g_beeping)
         return 20; // pump the tone fast until it finishes
 #endif
+    if (splashDone && kb.navHeld())
+        return 40; // a held arrow/backspace is repeating: poll+redraw fast for smooth scroll
     return splashDone ? 200 : 80; // 5 Hz normally; snappier while the splash is up
 }
 


### PR DESCRIPTION
Arrows emit on press + auto-repeat (350 ms / ~12 per s); backspace too. UI ticks at 40 ms while repeating for smooth scroll. Release suppressed, other keys end the repeat, 15 s failsafe. Typing symbols / Shift+arrow / long-ESC untouched. Hardware-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)