### PR TITLE
Companion: channel rename via set_channel + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ The Cardputer can act as a **keyboard + screen terminal for a separate Meshtasti
 
 A Bluetooth rune in the Chats header shows the link state; the link auto-reconnects after drops. **Settings → Radio** doubles as a status page (link signal, the node's battery, traffic; **R** reconnect, **F** forget the node). Switch back with **Radio → Onboard (Cap LoRa)**.
 
+You can also **configure the linked node from the Cardputer**, like the phone app does: Settings shows the *node's* values, **Name / Short / Channel** apply instantly over the link, and **Region / Preset / Frequency** make the node save and reboot itself while the link recovers on its own.
+
 > 📱 The node has a single Bluetooth slot — close the Meshtastic phone app while the Cardputer is linked, or they'll fight over it.
 
 ## Architecture
@@ -130,7 +132,7 @@ Requires PlatformIO. The build env is `m5stack-cardputer-adv-advui`. `scripts/sy
 
 The read **and** write paths are done and running on real hardware: node list, DMs, channels, delivery status, Cyrillic, emoji, reactions, replies, favourites, sound, timestamps, persisted history, on-device settings and BLE companion mode all work today. Companion mode is verified end-to-end over the air (encrypted DM through the linked node, routing ACK back).
 
-Next up: full-Unicode font from SD (CJK), remote node settings in companion mode, and quality-of-life polish.
+Next up: full-Unicode font from SD (CJK) and quality-of-life polish.
 
 ## License
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -88,7 +88,8 @@ the middle, the compose bar sits at the bottom.
 - **Delivery status** on your messages: a grey dot while sending → a **green ✓** on the
   routing ACK (channel broadcasts get their ✓ on transmit) → a **red ✗ with the reason** on
   failure. When the newest message has failed, **Enter resends it**.
-- **↑ / ↓** scroll the history; opening a thread auto-jumps to the first unread.
+- **↑ / ↓** scroll the history — **hold to keep scrolling** (arrows auto-repeat everywhere,
+  and so does backspace while erasing text); opening a thread auto-jumps to the first unread.
 - **Type** and hit **Enter** to send. **Fn+L** toggles the Cyrillic transliteration layer
   (the `RU`/`EN` badge on the compose bar; the choice persists). **Tab** opens the emoji
   palette (~24 icons, arrows + Enter to insert; emoji render inline in text).
@@ -118,6 +119,9 @@ the middle, the compose bar sits at the bottom.
 **↑/↓** move, **Enter** edits (or toggles), **ESC** backs out. Changes that affect the radio
 (Region / Preset / Frequency / Channel, WiFi / MQTT, Radio mode) reboot the device to apply.
 
+In **companion mode** the Name → Channel rows show — and edit — **the linked node** instead
+(see below); UTC / WiFi / MQTT / Radio stay local to the Cardputer.
+
 ### Companion mode (Settings → Radio → Companion via BLE)
 
 The Cardputer becomes a keyboard + screen terminal for **another, stock Meshtastic node**
@@ -138,6 +142,13 @@ link signal (dB), **the node's battery**, and how many nodes have synced. **R** 
 reconnect, **F** forgets the node (back to scan), **ESC** just leaves — the link stays up.
 Drops auto-reconnect in the background.
 
+**Settings drive the node remotely**, the way the phone app does: **Name / Short** and the
+**Channel** name apply instantly over the link (the channel object round-trips with its key,
+so the rename can't break encryption), while **Region / Preset / Frequency** make the node
+save and reboot itself — the screen drops to the Radio status page and the link comes back
+on its own. Screenless nodes usually pair with the stock PIN `123456` (the PIN screen
+reminds you).
+
 > 📱 The node has a single Bluetooth slot — close the Meshtastic phone app while the
 > Cardputer is linked, or they'll steal the connection from each other.
 
@@ -148,6 +159,6 @@ Drops auto-reconnect in the background.
 - **Sound + light:** one beep + green LED flash for favourites, a blue flash for everyone
   else — never a buzz per packet.
 - The node DB caps at 200 nodes on this hardware; the header shows `200+` when it's full.
-  In companion mode the synced node table holds the 64 most relevant nodes.
+  In companion mode the synced node table holds the 128 most recently heard nodes.
 - Other nodes' battery levels aren't stored by this build's compact node DB — only our own
   battery (header/footer) and, in companion mode, the linked node's.

--- a/overlay/src/advui/AdvBle.cpp
+++ b/overlay/src/advui/AdvBle.cpp
@@ -27,7 +27,7 @@ char g_linkErr[28] = {0};
 
 CompNode g_compNodes[kMaxCompNodes];
 volatile int g_compNodeCount = 0;
-CompChan g_compChans[8];
+meshtastic_Channel g_compChans[8];
 volatile bool g_linkConfigDone = false;
 volatile int g_compPreset = 0;
 meshtastic_Config_LoRaConfig g_compLora = meshtastic_Config_LoRaConfig_init_default;
@@ -284,15 +284,10 @@ void routeFromRadio(const uint8_t *bytes, uint16_t len)
             g_linkNodeBatt = ni.device_metrics.battery_level; // the radio node's own battery
         break;
     }
-    case meshtastic_FromRadio_channel_tag: {
-        const meshtastic_Channel &ch = fr.channel;
-        if (ch.index >= 0 && ch.index < 8) {
-            g_compChans[ch.index].role = (uint8_t)ch.role;
-            snprintf(g_compChans[ch.index].name, sizeof(g_compChans[ch.index].name), "%s",
-                     ch.has_settings ? ch.settings.name : "");
-        }
+    case meshtastic_FromRadio_channel_tag:
+        if (fr.channel.index >= 0 && fr.channel.index < 8)
+            g_compChans[fr.channel.index] = fr.channel;
         break;
-    }
     case meshtastic_FromRadio_config_tag:
         if (fr.config.which_payload_variant == meshtastic_Config_lora_tag) {
             g_compPreset = (int)fr.config.payload_variant.lora.modem_preset;

--- a/overlay/src/advui/AdvBle.h
+++ b/overlay/src/advui/AdvBle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "mesh/generated/meshtastic/channel.pb.h"
 #include "mesh/generated/meshtastic/config.pb.h"
 #include <cstddef>
 #include <cstdint>
@@ -62,11 +63,10 @@ struct CompNode {
 constexpr int kMaxCompNodes = 128;
 extern CompNode g_compNodes[kMaxCompNodes];
 extern volatile int g_compNodeCount;
-struct CompChan {
-    char name[12];
-    uint8_t role; // 0 disabled
-};
-extern CompChan g_compChans[8];
+// Full channel objects from the config stream. Kept whole — the PSK included —
+// so a rename can round-trip the channel back via set_channel without wiping
+// the key (the same reason the phone can edit channels).
+extern meshtastic_Channel g_compChans[8];
 extern volatile bool g_linkConfigDone; // config download finished
 extern volatile int g_compPreset;      // the node's LoRa modem preset (blank primary shows it)
 extern meshtastic_Config_LoRaConfig g_compLora; // the node's full LoRa config (remote admin edits it)

--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -343,10 +343,10 @@ const char *presetName(meshtastic_Config_LoRaConfig_ModemPreset p); // defined b
 const char *chanName(int i)
 {
     if (g_radioCompanion) {
-        if (g_compChans[i].name[0])
-            return g_compChans[i].name;
+        if (g_compChans[i].has_settings && g_compChans[i].settings.name[0])
+            return g_compChans[i].settings.name;
         // blank primary channel displays the modem preset, like stock does
-        if (g_compChans[i].role == 1)
+        if (g_compChans[i].role == meshtastic_Channel_Role_PRIMARY)
             return presetName((meshtastic_Config_LoRaConfig_ModemPreset)g_compPreset);
         return "?";
     }
@@ -356,7 +356,7 @@ const char *chanName(int i)
 bool chanEnabled(int i)
 {
     if (g_radioCompanion)
-        return g_compChans[i].role != 0;
+        return g_compChans[i].role != meshtastic_Channel_Role_DISABLED;
     return channels.getByIndex(i).role != meshtastic_Channel_Role_DISABLED;
 }
 
@@ -2375,6 +2375,17 @@ bool AdvUI::applyName()
         return true;
     }
     if (editTarget == 3) { // primary channel name; radio restart to apply
+        if (g_radioCompanion) { // remote rename: round-trip the synced channel object,
+                                // PSK included, so set_channel can't wipe the key
+            meshtastic_AdminMessage adm = meshtastic_AdminMessage_init_default;
+            adm.which_payload_variant = meshtastic_AdminMessage_set_channel_tag;
+            adm.set_channel = g_compChans[0];
+            strncpy(adm.set_channel.settings.name, nameBuf, sizeof(adm.set_channel.settings.name));
+            adm.set_channel.settings.name[sizeof(adm.set_channel.settings.name) - 1] = 0;
+            if (sendAdminToNode(adm)) // applied live on the node (no reboot); mirror it
+                g_compChans[0] = adm.set_channel;
+            return false;
+        }
         meshtastic_Channel ch = channels.getByIndex(0);
         strncpy(ch.settings.name, nameBuf, sizeof(ch.settings.name));
         ch.settings.name[sizeof(ch.settings.name) - 1] = 0;
@@ -3073,7 +3084,9 @@ void AdvUI::handleKey(char ch)
         if (esc) {
             mode = nameReturn;
         } else if (enter) {
-            bool rebooting = nameLen && applyName();
+            // A blank channel name is legitimate (it means "the preset default"), so the
+            // channel editor applies even when emptied; the other editors need text.
+            bool rebooting = (nameLen || editTarget == 3) && applyName();
             if (!rebooting)
                 mode = nameReturn;
         } else if (bksp) {
@@ -3144,10 +3157,11 @@ void AdvUI::handleKey(char ch)
             nameReturn = MODE_SETTINGS;
             mode = MODE_SETNAME;
         } else if (enter && setSel == 5) { // Channel name
-            if (g_radioCompanion)
-                return; // the node's PSK isn't synced over the link; a rename would wipe it
+            if (g_radioCompanion && !g_compChans[0].has_settings)
+                return; // channel not synced yet: nothing to round-trip
             editTarget = 3;
-            strncpy(nameBuf, channels.getByIndex(0).settings.name, sizeof(nameBuf));
+            strncpy(nameBuf, g_radioCompanion ? g_compChans[0].settings.name : channels.getByIndex(0).settings.name,
+                    sizeof(nameBuf));
             nameBuf[sizeof(nameBuf) - 1] = 0;
             nameLen = strlen(nameBuf);
             nameReturn = MODE_SETTINGS;


### PR DESCRIPTION
The companion table now keeps full channel objects (the config stream sends them PSK-included anyway), so the Channel row is editable: rename round-trips the synced object — the key can't be wiped. Applies live on the node, no reboot. Blank name = preset default, and the editor now accepts blanking. Docs updated (remote settings, 128-node cap, hold-to-scroll).

Note: rides the hardware-proven admin pipeline (set_owner/set_config), but the set_channel rename itself is code-verified only — the test node moved to WiFi (which disables its BLE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)