### PR TITLE
Render only when something changed

### DIFF
--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -4008,6 +4008,7 @@ int32_t AdvUI::runOnce()
 
     while (!g_radioCompanion && api.available() && api.getFromRadio(fromRadioBuf) > 0) {
         handleFromRadio(api.lastFromRadio()); // pick out incoming text messages (local radio mode)
+        uiDirty = true;
     }
 
     if (g_radioCompanion) { // companion: mesh packets arrive from the BLE pump's ring
@@ -4016,8 +4017,10 @@ int32_t AdvUI::runOnce()
         static meshtastic_FromRadio fr; // large struct: keep off the stack
         while (bleNextPacket(pbuf, &plen)) {
             fr = meshtastic_FromRadio_init_default;
-            if (pb_decode_from_bytes(pbuf, plen, &meshtastic_FromRadio_msg, &fr))
+            if (pb_decode_from_bytes(pbuf, plen, &meshtastic_FromRadio_msg, &fr)) {
                 handleFromRadio(fr); // same pipeline: messages, reactions, delivery ACKs
+                uiDirty = true;
+            }
         }
     }
 
@@ -4054,8 +4057,10 @@ int32_t AdvUI::runOnce()
             keyDuringSplash = true; // any key dismisses the splash early
         kb.trigger(); // re-read the FIFO as we drain (matches the stock poll loop)
     }
-    if (sawKey)
+    if (sawKey) {
         lastActivityMs = millis();
+        uiDirty = true;
+    }
     if (wakeOnly && sawKey)
         screenWake();
     kb.clearInt(); // re-arm the TCA8418 interrupt, else it stops reporting after the first event
@@ -4172,6 +4177,24 @@ int32_t AdvUI::runOnce()
         else
             return 200;
     }
+
+    // Redraw only when something changed: a key, a handled packet, a mode flip
+    // from a non-key path (auto-jump, PIN popups), a live screen (splash timing,
+    // scan hits, link counters), or the ~10 s refresh for battery %/ages. Idle
+    // frames cost a full 32 KB render + SPI push at 5 Hz otherwise.
+    bool liveScreen = !splashDone || mode == MODE_BLESCAN || mode == MODE_BLELINK;
+    if (!(uiDirty || liveScreen || mode != lastDrawnMode || millis() - lastDrawMs > 10000)) {
+#ifdef HAS_I2S
+        if (g_beeping)
+            return 20; // keep pumping the tone at the fast tick
+#endif
+        if (kb.navHeld())
+            return 40; // a held key is auto-repeating: keep the fast cadence
+        return 200;
+    }
+    uiDirty = false;
+    lastDrawnMode = mode;
+    lastDrawMs = millis();
 
     if (!splashDone)
         drawSplash();

--- a/overlay/src/advui/AdvUI.h
+++ b/overlay/src/advui/AdvUI.h
@@ -162,6 +162,9 @@ class AdvUI : public concurrency::OSThread
     bool inited = false;
     bool screenOn = true;        // display rail up; false = auto-off engaged
     uint32_t lastActivityMs = 0; // last key press, for the auto-off timer
+    bool uiDirty = true;         // something changed since the last frame -> redraw
+    Mode lastDrawnMode = MODE_CHATS; // catches mode flips from non-key paths
+    uint32_t lastDrawMs = 0;     // periodic refresh (battery %, ages) every ~10 s
     bool haveCanvas = false;
     bool splashDone = false;
     bool announced = false; // sent our early boot NodeInfo announce yet


### PR DESCRIPTION
Dirty-flag rendering: idle frames (full 32 KB render + SPI push at 5 Hz, list rebuilds with a 200-node sort included) are gone — a frame draws only on keys, handled packets, mode flips, live screens (splash/scan/link status), or the 10 s battery/ages refresh. Skip path preserves the beep (20 ms) and hold-scroll (40 ms) fast ticks. Hardware-verified, UX unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)