### PR TITLE
README: link to the screen gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ You get a device that boots straight into a usable messenger: pick a contact, ty
   <img src="docs/img/utc.png" width="32%" alt="UTC offset picker with cities"/>
 </p>
 
+<p align="center"><b><a href="docs/interface.md#screens-at-a-glance">▶ See every screen with captions →</a></b></p>
+
 ## Install
 
 The easiest way is the **[web installer](https://anton-vinogradov.github.io/meshtastic-adv/)** (ESP Web Tools):

--- a/README.ru.md
+++ b/README.ru.md
@@ -49,6 +49,8 @@ UI, написанный с нуля ради одной цели: чтобы **
   <img src="docs/img/utc.png" width="32%" alt="Выбор сдвига UTC по городам"/>
 </p>
 
+<p align="center"><b><a href="docs/interface.ru.md#экраны-с-одного-взгляда">▶ Все экраны с подписями →</a></b></p>
+
 ## Установка
 
 Проще всего — **[веб-инсталлятор](https://anton-vinogradov.github.io/meshtastic-adv/)** (ESP Web Tools):


### PR DESCRIPTION
Prominent pointer under the header screenshots (both languages) to the Screens at a glance gallery in interface.md — it wasn't discoverable from the landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)