### PR TITLE
Fix GoatCounter site code (randoom)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -182,7 +182,7 @@
     </footer>
   </main>
   <!-- GoatCounter: cookieless, privacy-first page-view + install-click stats -->
-  <script data-goatcounter="https://meshtastic-adv.goatcounter.com/count"
+  <script data-goatcounter="https://randoom.goatcounter.com/count"
           async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The analytics endpoint pointed at an unregistered site (400, no counting). Point it at the real dashboard randoom.goatcounter.com.