### PR TITLE
Installer: 8-bit theme for the flash dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 .idea/
 .DS_Store
 *.swp
+
+# M5Burner combined image (derivative of docs/*.bin)
+dist/

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,9 @@
                letter-spacing:1px; text-transform:uppercase; }
 
     /* --- install button --- */
-    esp-web-install-button{ display:block; }
+    esp-web-install-button{ display:block;
+      --esp-tools-button-color:var(--cyan); --esp-tools-button-text-color:#04121a;
+      --esp-tools-button-border-radius:0; }
     button[slot="activate"]{
       appearance:none; cursor:pointer; width:100%;
       font-family:"Press Start 2P", monospace; font-size:15px; color:#04121a;
@@ -57,6 +59,45 @@
     button[slot="activate"]:active{ transform:translateY(6px);
       box-shadow: 0 0 0 var(--cyanD), 0 0 0 3px #04121a; }
     .unsupported,.blocked{ display:block; color:var(--amber); font-size:20px; }
+
+    /* --- esp-web-tools install dialog → 8-bit theme ---
+       The dialog paints its theme on its own :host (a pseudo-class that
+       out-specificities a plain type selector), so we override the Material
+       design tokens on the host element with !important. It mounts in
+       document.body as <ewt-install-dialog>; custom props cascade into its
+       shadow tree and every ew-* child. */
+    ewt-install-dialog{
+      --roboto-font:"VT323", ui-monospace, monospace !important;
+      --md-ref-typeface-plain:"VT323", ui-monospace, monospace !important;
+      --md-ref-typeface-brand:"Press Start 2P", monospace !important;
+      --md-sys-typescale-title-font:"Press Start 2P", monospace !important;
+      --md-sys-typescale-headline-font:"Press Start 2P", monospace !important;
+
+      --md-sys-color-primary:var(--cyan) !important;
+      --md-sys-color-on-primary:#04121a !important;
+
+      --md-sys-color-surface:var(--panel) !important;
+      --md-sys-color-surface-container:var(--panel) !important;
+      --md-sys-color-surface-container-high:var(--panel) !important;
+      --md-sys-color-surface-container-highest:#0e1420 !important;
+      --md-sys-color-secondary-container:#12233d !important;
+      --md-sys-color-on-secondary-container:var(--ink) !important;
+
+      --md-sys-color-on-surface:var(--ink) !important;
+      --md-sys-color-on-surface-variant:var(--dim) !important;
+      --md-sys-color-outline:var(--line) !important;
+      --md-sys-color-outline-variant:var(--line) !important;
+
+      --text-color:var(--dim) !important;
+      --danger-color:var(--red) !important;
+
+      /* square corners to match the page's pixel panels */
+      --md-dialog-container-shape:0 !important;
+      --md-sys-shape-corner-large:0 !important;
+      --md-sys-shape-corner-medium:0 !important;
+      --md-sys-shape-corner-small:0 !important;
+      --md-sys-shape-corner-extra-small:0 !important;
+    }
 
     /* --- version picker --- */
     .verrow{ display:flex; align-items:center; gap:12px; margin-top:14px; }

--- a/scripts/mkm5burner.sh
+++ b/scripts/mkm5burner.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build a single-file firmware image for M5Stack's M5Burner.
+#
+# The web installer flashes two parts (see docs/manifest.json): the factory
+# image at 0x0 and the Unicode font partition at 0x340000. M5Burner flashes one
+# blob at 0x0, so we merge both into a single image with esptool. Without this,
+# an M5Burner install would boot fine but every non-embedded glyph (CJK, Arabic,
+# …) falls back to tofu, since the font partition would be empty.
+#
+# Output goes to dist/ (gitignored) — it is a pure derivative of the two bins in
+# docs/, regenerate any time. Usage: scripts/mkm5burner.sh [version]
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+VER="${1:-$(sed -n 's/.*"version": *"\([0-9.]*\).*/\1/p' docs/manifest.json)}"
+FONT_OFFSET=0x340000   # keep in sync with docs/manifest.json + partitions-advui.csv
+FACTORY=docs/firmware.factory.bin
+FONT=docs/unifont.bin
+OUT="dist/meshtastic-adv-v${VER}-m5burner.bin"
+
+for f in "$FACTORY" "$FONT"; do
+    [ -f "$f" ] || { echo "missing $f — build the firmware / run mkunifont.py first" >&2; exit 1; }
+done
+
+ESPTOOL="$(command -v esptool || command -v esptool.py || echo "$HOME/.platformio/penv/bin/esptool.py")"
+[ -x "$ESPTOOL" ] || { echo "esptool not found (looked in PATH and PlatformIO penv)" >&2; exit 1; }
+
+mkdir -p dist
+"$ESPTOOL" --chip esp32s3 merge-bin -o "$OUT" \
+    --flash-mode keep --flash-size keep \
+    0x0 "$FACTORY" "$FONT_OFFSET" "$FONT" 2>&1 | grep -vi deprecated || true
+
+# sanity: bootloader magic at 0x0, font magic at the partition offset
+python3 - "$OUT" "$FONT_OFFSET" <<'PY'
+import sys
+out, off = sys.argv[1], int(sys.argv[2], 0)
+b = open(out, 'rb').read()
+assert b[0] == 0xE9, "bad image: no 0xE9 boot magic at 0x0"
+assert b[off:off+4] == b'AUF1', "bad image: no AUF1 font blob at font offset"
+print(f"ok: {out} ({len(b):,} bytes) — boot magic + AUF1 verified")
+PY
+echo "flash at offset 0x0 in M5Burner."


### PR DESCRIPTION
Themes the esp-web-tools install popup (device dashboard, erase/install steps, logs) to match the pixel installer — dark surface, cyan primary, VT323/Press Start 2P fonts, square corners. Verified across dialog states in-browser with a mocked serial port. Pure CSS custom properties scoped to `ewt-install-dialog`; no effect on the actual flash flow.