### PR TITLE
flash.sh: auto-set device clock from the host

### DIFF
--- a/scripts/flash.sh
+++ b/scripts/flash.sh
@@ -86,3 +86,10 @@ for attempt in range(3):
 if not booted:
     print(">> flashed, but couldn't confirm the reset — if the screen stays black, unplug/replug once")
 PYEOF
+
+# No battery-backed RTC: every flash boots clockless and messages would stamp
+# timeless until a phone/NTP/mesh sync. Push the host's time over the serial
+# PhoneAPI once the app is up. Best-effort: a failure never fails the flash.
+echo ">> setting the device clock from the host"
+sleep 8 # let the app finish booting before opening an API session
+"$PY" "$ROOT/scripts/settime.py" "$(find_port)" || true

--- a/scripts/settime.py
+++ b/scripts/settime.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# Set the device clock to the host's time over the serial PhoneAPI.
+#
+# The board has no battery-backed RTC, so every reboot (and thus every flash)
+# loses the clock and messages get stamped timeless until some source sets it.
+# flash.sh calls this after an upload so the dev loop never runs clockless; it
+# lands as set_time_only -> RTCQualityNTP, so it also outranks a manual entry.
+# Usage: settime.py [port]
+import sys, threading, time
+
+import meshtastic.serial_interface
+
+# The lib's background reader can choke on a stray boot-log line mid-stream and
+# dump a traceback; the admin write itself still goes through. Keep the output clean.
+threading.excepthook = lambda args: None
+
+port = sys.argv[1] if len(sys.argv) > 1 else None
+try:
+    iface = meshtastic.serial_interface.SerialInterface(devPath=port)
+    iface.localNode.setTime()  # 0 = host's current time
+    time.sleep(1)              # let the admin frame drain before closing
+    iface.close()
+    print("device clock set to host time")
+except Exception as e:
+    print(f"settime skipped: {e}", file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
Every flash boots clockless (no battery RTC) and pre-sync messages stay timeless forever. flash.sh now pushes host time over the serial PhoneAPI (`set_time_only` → `RTCQualityNTP`) after the post-flash reset, best-effort. Verified on hardware: log stamps flip from `??:??:??` to real time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)