### PR TITLE
Fix missing delivery check on own channel messages

### DIFF
--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -2026,8 +2026,17 @@ void AdvUI::handleFromRadio(const meshtastic_FromRadio &fr)
     }
 
     bool unread = p.from != me && (p.to == me || p.to == NODENUM_BROADCAST); // DM to us, or a channel broadcast
+    // Our own broadcasts are delivered back to us locally (loopbackOk), and that echo
+    // runs SYNCHRONOUSLY inside sendTextPacket() — before sendChannel() tags the message
+    // MSG_SENT. Storing the echo as MSG_IN would then win the id dedupe in addMsg() and
+    // the "sent" check would never draw. So stamp our own echoed sends with their real
+    // outgoing status: a channel broadcast is MSG_SENT (no ack); a DM loopback, should one
+    // ever occur, stays MSG_SENDING until its routing ACK flips it via ackMsg().
+    uint8_t status = MSG_IN;
+    if (p.from == me)
+        status = (p.to == NODENUM_BROADCAST) ? MSG_SENT : MSG_SENDING;
     // keep the id (reactions/replies reference it) and the reply link (draws the quote)
-    addMsg(p.from, p.to, p.channel, p.rx_time, unread, text, p.id, MSG_IN, p.decoded.reply_id);
+    addMsg(p.from, p.to, p.channel, p.rx_time, unread, text, p.id, status, p.decoded.reply_id);
 
     if (unread) {
         bool fav = (p.to == NODENUM_BROADCAST) ? chanFav(p.channel) : (!g_radioCompanion && nodeDB && nodeDB->isFavorite(p.from));


### PR DESCRIPTION
## Bug
Messages sent to a **channel** showed no delivery-status glyph on the Cardputer — the "sent" check never appeared to their right. DMs were fine.

## Root cause
Our own broadcasts are delivered back to us locally (`AdvRxModule` sets `loopbackOk = true`), and that echo runs **synchronously inside `sendTextPacket()`** — before `sendChannel()` can tag the message `MSG_SENT`. `handleFromRadio()` stored the echo as `MSG_IN`, which then won the id dedupe in `addMsg()`, so the message stayed `MSG_IN` and `drawMsgStatus()` drew nothing.

DMs were unaffected: a DM addressed to a peer isn't delivered locally, so there was no premature echo (which is also why the on-load migration at `runOnce` already upgrades old `MSG_IN` own-broadcasts to `MSG_SENT`).

## Fix
Stamp our own echoed sends with their real outgoing status in `handleFromRadio()`: a channel broadcast → `MSG_SENT`; a DM loopback, should one ever occur, stays `MSG_SENDING` until its routing ACK.

## Testing
Built for `m5stack-cardputer-adv-advui`, flashed to hardware (config preserved), confirmed the cyan "sent" check now appears on channel messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
