### PR TITLE
On-device UI fixes: WiFi status, GPS toggle, read-on-open

### DIFF
--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -126,13 +126,13 @@ const char *errName(uint8_t e)
 constexpr int kMaxMsgs = 32; // shared across all conversations; DMs are protected by the
                              // channel-first eviction (addMsg), not by size, so this stays small
                              // to keep the heap margin — a connected phone + BLE runs it thin
-constexpr int kNumSettings = 17; // the flat item table: Name..Channel, Role..Rebroadcast, UTC, WiFi, MQTT, Screen, Radio, Font, Clock
+constexpr int kNumSettings = 18; // the flat item table: Name..Channel, Role..Rebroadcast, UTC, WiFi, MQTT, Screen, Radio, Font, Clock, GPS
 
 // The Settings menu is two-level: the top lists sections (plus WiFi/MQTT/Radio
 // as direct entries); a section lists indices into the flat item table.
 const uint8_t kSecNode[] = {0, 1};                    // Name, Short
 const uint8_t kSecLora[] = {2, 3, 4, 5, 6, 7, 8, 9};  // Region..Rebroadcast
-const uint8_t kSecDevice[] = {10, 16, 13, 15};        // UTC, Clock, Screen, Font (read-only)
+const uint8_t kSecDevice[] = {10, 16, 13, 17, 15};    // UTC, Clock, Screen, GPS, Font (read-only)
 constexpr int kTopCount = 6;                          // Node, LoRa, WiFi, MQTT, Device, Radio
 Msg g_msgs[kMaxMsgs];
 int g_msgCount = 0;         // populated slots (grows to kMaxMsgs)
@@ -1196,6 +1196,7 @@ const EnumOpt kPowerOpts[] = {{"max (region)", 0}, {"2 dBm", 2},   {"5 dBm", 5},
                               {"14 dBm", 14},      {"17 dBm", 17}, {"20 dBm", 20}, {"22 dBm", 22}};
 const EnumOpt kRebroadOpts[] = {{"All", 0},        {"All skip decode", 1}, {"Local only", 2},
                                 {"Known only", 3}, {"Core ports only", 5}, {"None", 4}};
+const EnumOpt kGpsOpts[] = {{"On", 1}, {"Off", 0}}; // config.position.gps_mode ENABLED / DISABLED
 constexpr int kRegionCount = sizeof(kRegionOpts) / sizeof(kRegionOpts[0]);
 constexpr int kPresetCount = sizeof(kPresetOpts) / sizeof(kPresetOpts[0]);
 constexpr int kUtcCount = sizeof(kUtcOpts) / sizeof(kUtcOpts[0]);
@@ -1205,6 +1206,7 @@ constexpr int kRoleCount = sizeof(kRoleOpts2) / sizeof(kRoleOpts2[0]);
 constexpr int kHopCount = sizeof(kHopOpts) / sizeof(kHopOpts[0]);
 constexpr int kPowerCount = sizeof(kPowerOpts) / sizeof(kPowerOpts[0]);
 constexpr int kRebroadCount = sizeof(kRebroadOpts) / sizeof(kRebroadOpts[0]);
+constexpr int kGpsCount = sizeof(kGpsOpts) / sizeof(kGpsOpts[0]);
 
 // The settings list-pickers, keyed by pickTarget.
 struct PickList {
@@ -1233,6 +1235,7 @@ PickList pickListFor(int target)
     case 6: return {kHopOpts, kHopCount, "Hop limit"};
     case 7: return {kPowerOpts, kPowerCount, "TX power"};
     case 8: return {kRebroadOpts, kRebroadCount, "Rebroadcast"};
+    case 9: return {kGpsOpts, kGpsCount, "GPS"};
     default: return {kRadioOpts, kRadioCount, "Radio"};
     }
 }
@@ -3425,7 +3428,7 @@ void AdvUI::drawSettings()
     const char *labels[kNumSettings] = {"Name", "Short",       "Region", "Preset", "Frequency",
                                         "Channel", "Role",     "Hops",   "Power",  "Rebroadcast",
                                         "UTC",     "WiFi",     "MQTT",   "Screen", "Radio",
-                                        "Font",    "Clock"};
+                                        "Font",    "Clock",    "GPS"};
     char vals[kNumSettings][24];
     if (g_radioCompanion) { // rows 0-5 show (and remote-admin edit) the linked node
         meshtastic_NodeInfoLite *me = g_linkMyNode ? nodeByNum(g_linkMyNode) : nullptr;
@@ -3501,6 +3504,7 @@ void AdvUI::drawSettings()
         } else
             strcpy(vals[16], "not set");
     }
+    strcpy(vals[17], config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED ? "on" : "off");
 
     // What the current level shows: top = sections + direct entries (with a
     // representative value as the preview), sub = the section's flat items.
@@ -4424,6 +4428,12 @@ void AdvUI::openSetting(int item)
         pickSel = g_radioCompanion ? 1 : 0;
         pickScroll = 0;
         mode = MODE_PICKLIST;
+    } else if (item == 17) { // GPS on/off (local device position config)
+        pickTarget = 9;
+        pickSel = optIndex(kGpsOpts, kGpsCount,
+                           config.position.gps_mode == meshtastic_Config_PositionConfig_GpsMode_ENABLED ? 1 : 0);
+        pickScroll = 0;
+        mode = MODE_PICKLIST;
     } else if (item == 11 || item == 12) { // WiFi / MQTT sub-page
         netPage = item == 11 ? 0 : 1;
         netSel = 0;
@@ -4684,6 +4694,15 @@ void AdvUI::handleKey(char ch)
                 } else {
                     mode = MODE_SETTINGS;
                 }
+            } else if (pickTarget == 9) { // GPS on/off: persist + reboot so the GPS thread re-reads it
+                config.position.gps_mode = kGpsOpts[pickSel].value
+                                               ? meshtastic_Config_PositionConfig_GpsMode_ENABLED
+                                               : meshtastic_Config_PositionConfig_GpsMode_DISABLED;
+                config.has_position = true;
+                if (nodeDB)
+                    nodeDB->saveToDisk(SEGMENT_CONFIG);
+                rebootAtMsec = millis() + 1500;
+                mode = MODE_REBOOT;
             } else {
                 // Region/Preset/Role/Hops/Power/Rebroadcast: radio config, needs a
                 // reboot (ours, or the linked node's via remote admin).

--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -18,6 +18,10 @@
 #include "graphics/emotes.h" // UTF-8 -> bitmap emoji table (forced in via EmotesData.cpp)
 #include "main.h" // audioThread (I2S beep)
 #include "modules/NodeInfoModule.h"
+#if HAS_WIFI
+#include "mesh/wifi/WiFiAPClient.h" // getWifiDisconnectReason()
+#include <WiFi.h>                    // live WiFi.status()/localIP()/RSSI() for the settings page
+#endif
 #ifdef HAS_NEOPIXEL
 #include "esp32-hal-rgb-led.h" // rgbLedWrite(): stateless RMT driver for the onboard RGB LED
 #include <Esp.h>
@@ -3619,6 +3623,53 @@ void AdvUI::drawNetPage()
         g->setCursor(236 - g->textWidth(v), y + 1);
         g->print(v);
     }
+
+#if HAS_WIFI
+    // Live connection status (WiFi page only): the rows above show what's configured,
+    // this shows what the radio is actually doing right now — so a wrong network or a
+    // 5 GHz SSID reads as "AP not found" on the device instead of just silently not
+    // connecting (which is exactly how it used to fail with no on-device feedback).
+    if (netPage == 0 && config.network.wifi_enabled) {
+        int sy = top + 3 * rowH + 8; // just below the 3 WiFi fields
+        g->drawFastHLine(0, sy - 6, 240, 0x39C7);
+        g->setFont(&lgfx::fonts::FreeSansBold9pt7b);
+        g->setTextSize(1);
+        g->setTextColor(0xFFFF);
+        g->setCursor(6, sy);
+        g->print("Status");
+
+        char st[24];
+        uint16_t col;
+        int ws = WiFi.status();
+        uint8_t rsn = getWifiDisconnectReason();
+        if (ws == WL_CONNECTED) {
+            col = 0x07E0; // green
+            strcpy(st, "connected");
+        } else if (ws == WL_NO_SSID_AVAIL || rsn == 201) { // 201 = NO_AP_FOUND
+            col = 0xF800;                                  // red
+            strcpy(st, "AP not found");
+        } else if (ws == WL_CONNECT_FAILED || rsn == 15 || rsn == 2) { // bad password / auth
+            col = 0xF800;
+            strcpy(st, "auth failed");
+        } else {
+            col = 0xFFE0; // yellow
+            strcpy(st, "connecting...");
+        }
+        fitWidth(g, st, 150);
+        g->setTextColor(col);
+        g->setCursor(236 - g->textWidth(st), sy);
+        g->print(st);
+
+        if (ws == WL_CONNECTED) { // second line: IP + signal once the link is up
+            char ln[40];
+            snprintf(ln, sizeof(ln), "%s  %ddBm", WiFi.localIP().toString().c_str(), (int)WiFi.RSSI());
+            g->setFont(&lgfx::fonts::Font0);
+            g->setTextColor(0x9CD3);
+            g->setCursor(6, sy + 16);
+            g->print(ln);
+        }
+    }
+#endif
 
     drawFooter(g, netDirty ? "ENTER edit   ESC save+reboot" : "ENTER edit   ESC back");
 

--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -3066,8 +3066,29 @@ void AdvUI::drawNode()
         // chatScroll counts lines scrolled up from the bottom (0 = pinned to newest).
         int maxScroll = dlCount > maxLines ? dlCount - maxLines : 0;
         bool jumpedNow = false;
-        if (chatAnchorMsgIdx >= 0) { // first render after opening: jump to the first unread
-            if (anchorLine >= 0 && anchorLine <= maxScroll)
+        if (chatAnchorMsgIdx >= 0) { // first render after opening
+            // A short thread with only a handful of unread is effectively all on
+            // screen on open (even a wrapped 2-3-message channel is a few lines over
+            // the fold). Jumping to the first unread at the top would then strand the
+            // newest line just below the visible window, so it never gets "seen" and
+            // the channel stays unread until you scroll. Instead: pin to the newest
+            // and mark the whole thread read now. A genuine backlog (more unread than
+            // a screenful) still jumps to the first unread and clears as you read down.
+            int unread = 0;
+            for (int j = 0; j < g_msgCount; j++) {
+                const Msg &m = g_msgs[j];
+                bool match = isChan ? (m.to == NODENUM_BROADCAST && m.ch == selectedChannel)
+                                    : (m.from == selectedNum && m.to != NODENUM_BROADCAST);
+                if (match && !m.read)
+                    unread++;
+            }
+            if (unread > 0 && unread <= maxLines) { // not a backlog: read it all on open
+                chatScroll = 0;
+                if (isChan)
+                    markReadChannel(selectedChannel);
+                else
+                    markReadFrom(selectedNum);
+            } else if (anchorLine >= 0 && anchorLine <= maxScroll)
                 chatScroll = maxScroll - anchorLine;
             else if (anchorDropped)
                 chatScroll = maxScroll; // unread starts beyond the ring: as far back as we can show


### PR DESCRIPTION
Three on-device UI fixes.

### 1. Live WiFi status on the settings page (`d1636b1`)
The WiFi page only showed the configured SSID/toggle, so a failed join (wrong network, a 5 GHz-only SSID, out of range) looked identical to a working one. Adds a live status line: green **connected** + IP + RSSI; red **AP not found** (`WL_NO_SSID_AVAIL` / disconnect reason 201); red **auth failed** (`WL_CONNECT_FAILED` / reason 15/2); yellow **connecting…**. Reads the stock `WiFi.status()`/`localIP()`/`RSSI()` and `getWifiDisconnectReason()`; `HAS_WIFI`-guarded, shown only when `wifi_enabled`.

### 2. GPS on/off toggle (`b39a96f`)
Settings → Device gains a **GPS** row (on/off) so the onboard GPS can be turned off on the device. Uses the existing picker framework (pickTarget 9): writes `config.position.gps_mode` (ENABLED/DISABLED), persists, and reboots so the GPS thread re-reads it — same apply path as Region/Role.

### 3. Mark short threads read on open (`934f70c`)
Read state clears per message as its line reaches the screen, and opening a thread jumped to the first unread at the **top**. Channel messages wrap (`HH:MM Name: text`), so even 2–3 unread pushed the newest line just below the fold — it never got drawn, so the channel stayed unread until you scrolled or started typing. Now: when a thread has at most a screenful of unread (not a backlog), pin to the newest and mark the whole thread read via `markReadChannel`/`markReadFrom` (until now dead code — also clears their unused-function warnings). A real backlog still jumps to the first unread and clears as you read down.

### Testing
All three build clean for `m5stack-cardputer-adv-advui`. Not yet exercised on hardware (device in use) — logic reviewed against the existing settings/render framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
