### PR TITLE
Blocking CDC writes while a serial API client is connected

### DIFF
--- a/scripts/sync-overlay.sh
+++ b/scripts/sync-overlay.sh
@@ -44,14 +44,27 @@ if [ -f "$MC" ] && ! grep -q 'advui-inject' "$MC"; then
   echo "injected advui hooks into main.cpp"
 fi
 
-# SerialConsole.cpp: in the ADVUI_SCREENSHOT dev build the remote-debug driver
-# owns serial input (keys/screenshots); the stock console polls-and-drains the
-# same port whenever USB is plugged and would eat those bytes. Dead code in
-# release builds (the flag is never set there).
+# SerialConsole.cpp, two independent injections:
+#  1. in the ADVUI_SCREENSHOT dev build the remote-debug driver owns serial
+#     input (keys/screenshots); the stock console polls-and-drains the same
+#     port whenever USB is plugged and would eat those bytes. Dead code in
+#     release builds (the flag is never set there).
+#  2. the boot-time zero TX timeout (main.cpp injection above) makes USB-CDC
+#     writes droppable: under pressure HWCDC::write() returns short, and a
+#     PhoneAPI frame cut mid-body corrupts the whole stream for the client
+#     ("Wire format was corrupt" in the python lib). While an API client is
+#     on the line it IS draining the port, so blocking writes are cheap —
+#     switch to them on the first ToRadio protobuf, and fall back to the
+#     non-blocking boot behavior once the client goes away.
 SC="$FW/src/SerialConsole.cpp"
-if [ -f "$SC" ] && ! grep -q 'advui-inject' "$SC"; then
+if [ -f "$SC" ] && ! grep -q 'the screenshot build reads serial itself' "$SC"; then
   perl -0pi -e 's{(int32_t SerialConsole::runOnce\(\)\n\{\n)}{$1#ifdef ADVUI_SCREENSHOT\n    return 250; // advui-inject: the screenshot build reads serial itself\n#endif\n}' "$SC"
-  echo "injected advui hook into SerialConsole.cpp"
+  echo "injected advui screenshot hook into SerialConsole.cpp"
+fi
+if [ -f "$SC" ] && ! grep -q 'advui-inject-txto' "$SC"; then
+  perl -0pi -e 's{(usingProtobufs = true;\n        canWrite = true;\n)}{$1#ifdef IS_USB_SERIAL\n        // advui-inject-txto: an API client is draining the CDC, so blocking\n        // writes are cheap and keep PhoneAPI frames whole; with the boot-time\n        // zero timeout a frame cut short by a full TX ring corrupts the stream.\n        Port.setTxTimeoutMs(50);\n#endif\n}' "$SC"
+  perl -0pi -e 's{(\n    int32_t delay = runOncePart\(\);)}{\n#ifdef IS_USB_SERIAL\n    if (!checkIsConnected())\n        Port.setTxTimeoutMs(0); // advui-inject-txto: client gone -> non-blocking boot behavior\n#endif$1}' "$SC"
+  echo "injected advui tx-timeout hooks into SerialConsole.cpp"
 fi
 
 echo "overlay synced into $FW"


### PR DESCRIPTION
## Problem

Connecting the python client over serial (e.g. `scripts/settime.py`, which `flash.sh` runs after every upload) died with:

```
google.protobuf.message.DecodeError: Error parsing message with type 'meshtastic.protobuf.FromRadio': Wire format was corrupt
settime skipped: Timed out waiting for interface config
```

## Root cause

Our own boot injection `Serial.setTxTimeoutMs(0)` (kept boot logging from stalling when nobody drains the CDC port) makes every USB-CDC write droppable. With a zero timeout, `HWCDC::write()` gives up on a full 256-byte TX ring within microseconds — far faster than the host can drain — and returns short. By then `StreamAPI::writeFrame()` has already put the frame header on the wire, so a frame cut mid-body shifts every byte that follows and the client's reader thread dies before `config_complete_id` arrives.

A raw capture of the port made it visible directly: a frame header announces 57–66 bytes, and after ~26–56 bytes of body the next `DEBUG | ...` log line starts right inside the frame. **99 of 172 frames were truncated**; the config dump never completed.

It used to work because the failure is probabilistic — it went near-certain once the node DB grew to ~170 nodes (busy city mesh): the `want_config` reply became a multi-KB burst into the 256-byte ring, with debug text competing for the same ring.

## Fix

Two new `sync-overlay.sh` injections into `SerialConsole.cpp` (marker `advui-inject-txto`):

- `handleToRadio()`: the first ToRadio protobuf proves a client is draining the port, so switch to blocking writes (`setTxTimeoutMs(50)`) — cheap while someone reads, and frames stay whole;
- `runOnce()`: once the client has been silent past the serial connection timeout, fall back to the non-blocking boot behavior (`setTxTimeoutMs(0)`).

The SerialConsole injection guards are now per-marker: the old file-wide `grep -q 'advui-inject'` would have refused to add a second block to an already-injected tree.

## Verification (on hardware)

- Raw capture after the fix: **0 of 272 frames corrupt**, full config dump lands (`my_info`, 8 channels, config, moduleConfig, 170 `node_info`, `config_complete_id`).
- `settime.py` succeeds end-to-end, twice (via `flash.sh` and standalone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
