### PR TITLE
Fix PhoneAPI config dump never completing on a large nodedb

### DIFF
--- a/overlay/patches/nodedb-oom-save.patch
+++ b/overlay/patches/nodedb-oom-save.patch
@@ -1,0 +1,42 @@
+diff --git a/src/mesh/NodeDB.cpp b/src/mesh/NodeDB.cpp
+index 3e877a57c..9a6398d8f 100644
+--- a/src/mesh/NodeDB.cpp
++++ b/src/mesh/NodeDB.cpp
+@@ -2779,6 +2779,15 @@ bool NodeDB::saveNodeDatabaseToDisk()
+     // Project the maps into the on-disk vectors just before encoding; cleared
+     // again on the way out so we don't carry duplicate state.
+     concurrency::LockGuard guard(&satelliteMutex);
++    // advui-inject-oomsave: the four reserve() calls below each want a
++    // contiguous multi-KB block (~200 entries per map); on a heap ground down
++    // to a few KB the resulting std::bad_alloc was escaping to std::terminate
++    // and rebooting the node mid-operation. Defer the save instead - the next
++    // cadence retries with whatever the heap looks like then. Returning true,
++    // not false: false sends saveToDisk() down its retry/format path.
++#if defined(__cpp_exceptions) || defined(__EXCEPTIONS)
++    try {
++#endif
+ #if !MESHTASTIC_EXCLUDE_POSITIONDB
+     nodeDatabase.positions.clear();
+     nodeDatabase.positions.reserve(nodePositions.size());
+@@ -2834,6 +2843,21 @@ bool NodeDB::saveNodeDatabaseToDisk()
+ #else
+     nodeDatabase.status.clear();
+ #endif
++#if defined(__cpp_exceptions) || defined(__EXCEPTIONS)
++    } catch (const std::bad_alloc &) {
++        // advui-inject-oomsave: heap too tight to stage the satellite data.
++        nodeDatabase.positions.clear();
++        nodeDatabase.positions.shrink_to_fit();
++        nodeDatabase.telemetry.clear();
++        nodeDatabase.telemetry.shrink_to_fit();
++        nodeDatabase.environment.clear();
++        nodeDatabase.environment.shrink_to_fit();
++        nodeDatabase.status.clear();
++        nodeDatabase.status.shrink_to_fit();
++        LOG_WARN("NodeDB save deferred: heap too low to stage satellite data");
++        return true;
++    }
++#endif
+ 
+     size_t nodeDatabaseSize;
+     pb_get_encoded_size(&nodeDatabaseSize, meshtastic_NodeDatabase_fields, &nodeDatabase);

--- a/overlay/src/advui/AdvNodeCap.cpp
+++ b/overlay/src/advui/AdvNodeCap.cpp
@@ -9,7 +9,14 @@
 // NodeInfoLite vector costs is exactly the DRAM the BLE central + SMP pairing
 // need. 32 slots still fit our own entry plus any favourites, so switching
 // back to onboard LoRa keeps them (the rest of the mesh is re-learned off the
-// air). Local mode keeps the stock flash-size tiering.
+// air).
+//
+// Local mode does NOT follow the stock flash-size tiering: this board has 16 MB
+// flash but no PSRAM, so DRAM — not flash — is the ceiling. The stock 250-node
+// tier is a ~40 KB NodeInfoLite vector, and that is exactly what tips a
+// WiFi+HTTPS build into out-of-memory reboots on a busy mesh. Cap the hot store
+// at 150 (matches WARM_NODE_COUNT, so each evicted node keeps exactly one warm
+// slot and DMs to it still decrypt); the tail lives in the flash warm tier.
 //
 // Runs from NodeDB's constructor — after fsInit(), long before the UI loads
 // its radio config — so it reads /advui_radio.bin (AVR1) directly.
@@ -35,7 +42,7 @@ int advui_max_num_nodes()
         cached = 32;
     } else {
         uint32_t flashMb = ESP.getFlashChipSize() / (1024 * 1024);
-        cached = flashMb >= 15 ? 250 : flashMb >= 7 ? 200 : 100;
+        cached = flashMb >= 7 ? 150 : 100;
     }
     return cached;
 }

--- a/scripts/sync-overlay.sh
+++ b/scripts/sync-overlay.sh
@@ -67,4 +67,41 @@ if [ -f "$SC" ] && ! grep -q 'advui-inject-txto' "$SC"; then
   echo "injected advui tx-timeout hooks into SerialConsole.cpp"
 fi
 
+# WebServer.cpp + ContentHandler.cpp: drop the HTTPS/TLS server, keep HTTP:80.
+# The self-signed RSA-2048 cert plus mbedTLS session state costs tens of KB of
+# heap on this no-PSRAM board — the stock code already logs "skipping HTTPS
+# processing" under memory pressure, and every local tool talks to :80 anyway.
+# Nulling secureServer leans on the stock `if (secureServer)` guards around
+# loop()/start(); the handler-registration block (unguarded upstream) is wrapped
+# to match, and the cert generator is short-circuited so a clean install never
+# spends the RSA-keygen heap spike on a tight heap.
+WS="$FW/src/mesh/http/WebServer.cpp"
+if [ -f "$WS" ] && ! grep -q 'advui-inject-nohttps' "$WS"; then
+  perl -0pi -e 's{secureServer = new HTTPSServer\(cert, 443, MAX_HTTPS_CONNECTIONS\);}{secureServer = nullptr; // advui-inject-nohttps: HTTPS off, keep HTTP:80 -> frees tens of KB heap}' "$WS"
+  perl -0pi -e 's{(void createSSLCert\(\)\n\{\n)}{$1    return; // advui-inject-nohttps: HTTPS disabled, skip the RSA-2048 self-signed cert gen\n}' "$WS"
+  echo "injected advui no-HTTPS hooks into WebServer.cpp"
+fi
+CH="$FW/src/mesh/http/ContentHandler.cpp"
+if [ -f "$CH" ] && ! grep -q 'advui-inject-nohttps' "$CH"; then
+  # @-delimited: the replacement carries C++ braces, which would unbalance s{}{}.
+  perl -0pi -e 's@(    secureServer->registerNode\(nodeAPIv1ToRadioOptions\);)@    if (secureServer) { // advui-inject-nohttps: HTTPS server is not created\n$1@' "$CH"
+  perl -0pi -e 's@(    secureServer->registerNode\(nodeRoot\); // This has to be last\n)@$1    } // advui-inject-nohttps\n@' "$CH"
+  echo "injected advui no-HTTPS guard into ContentHandler.cpp"
+fi
+
+# NodeDB.cpp: saveNodeDatabaseToDisk() stages the four satellite maps into
+# on-disk vectors with reserve() calls that each want a contiguous multi-KB
+# block. On this no-PSRAM board under a busy mesh the heap can be ground low
+# enough that std::bad_alloc escapes to std::terminate and reboots the node
+# mid-operation — which, when it lands during a PhoneAPI config dump (a save is
+# triggered by every incoming NodeInfo), is exactly what stops the dump from
+# ever reaching config_complete_id. Wrap the staging in a bad_alloc catch that
+# defers the save (returns true, not false — false would send saveToDisk() down
+# its retry/fsFormat path). Applied as a patch: it spans two hunks.
+ND="$FW/src/mesh/NodeDB.cpp"
+if [ -f "$ND" ] && ! grep -q 'advui-inject-oomsave' "$ND"; then
+  git -C "$FW" apply "$ROOT/overlay/patches/nodedb-oom-save.patch"
+  echo "injected advui oom-save patch into NodeDB.cpp"
+fi
+
 echo "overlay synced into $FW"


### PR DESCRIPTION
## Problem

`want_config` never reached `config_complete_id` once the local nodedb grew large (~350-node mesh). The device ran out of heap mid-dump and died three different ways depending on transport — all symptoms of the same ~13 KB idle heap being tipped over by the dump:

- **serial** — an incoming `NodeInfo` from the mesh triggers `NodeDB::updateUser → saveToDisk → saveNodeDatabaseToDisk`, whose `reserve()` calls throw `std::bad_alloc`, which escapes to `std::terminate` and reboots the node (caught the panic + backtrace at `NodeDB.cpp` `saveNodeDatabaseToDisk`). This was the `settime` "Timed out waiting for connection completion" — a reboot mid-dump, not a timeout.
- **TCP 4403** — LWIP can't allocate socket buffers under the low heap (`write()` EAGAIN `errno 11`), so the stream stalls right after `my_info`/channels and the client times out.
- **HTTPS** — TLS under a starved heap blocks `loopTask` into a task watchdog reboot.

## Fix

Give the headroom back:

- **Cap the local hot node store at 150** (was 250/200). DRAM, not flash, is the ceiling on this no-PSRAM S3; the 250-tier ~40 KB `NodeInfoLite` vector is what pushes a WiFi build into OOM reboots on a busy mesh. 150 matches `WARM_NODE_COUNT`, so each evicted node keeps a warm slot and DMs still decrypt.
- **Drop the HTTPS/TLS server, keep HTTP:80** (`advui-inject-nohttps`): local tools talk to :80 anyway, and the self-signed cert + mbedTLS state cost tens of KB.
- **Defer the NodeDB save on `std::bad_alloc`** instead of letting it escape to `std::terminate` (`overlay/patches/nodedb-oom-save.patch`; returns `true`, not `false`, so `saveToDisk` doesn't take its retry/fsFormat path).

## Verification (on hardware, FADV)

- Config dump completes in **0.3–2.5 s** (149–150 nodes incl. 17 `fileInfo` frames) over raw TCP, the official meshtastic `TCPInterface` (CONNECTED in 0.7 s), and serial (`settime` config handshake completes).
- Idle free heap up from **~13 KB → ~27 KB**; **no reboots** across many dump cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)