### PR TITLE
Text editor buffer was 24 chars while allowing 63 — long passwords truncated

### DIFF
--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -4815,6 +4815,8 @@ void AdvUI::handleKey(char ch)
 
     if (mode == MODE_SETNAME) {
         unsigned maxLen = editMax(editTarget);
+        if (maxLen > sizeof(nameBuf) - 1) // never write past the shared editor buffer
+            maxLen = sizeof(nameBuf) - 1;
         bool numeric = (editTarget == 2 || editTarget == 4); // frequency: digits + '.'; clock: digits + ':'
         if (esc) {
             mode = nameReturn;

--- a/overlay/src/advui/AdvUI.h
+++ b/overlay/src/advui/AdvUI.h
@@ -156,7 +156,12 @@ class AdvUI : public concurrency::OSThread
     uint8_t msgLen = 0;
     char pendingLat = 0;      // last Latin letter that may still start a digraph (sh/ya/...)
 
-    char nameBuf[25] = {0};   // node-name editor buffer (MODE_SETNAME)
+    // Shared text-editor buffer (MODE_SETNAME). Sized for the LONGEST field it
+    // ever edits, not for node names: the WiFi/MQTT pages reuse this editor and
+    // editMax() allows up to 63 chars there (wifi_psk[65], mqtt address[64]).
+    // At 25 bytes a long password overran the struct and was silently truncated
+    // to 24 chars on save — the saved credential then never matched.
+    char nameBuf[65] = {0};
     uint8_t nameLen = 0;
     int editTarget = 0;       // MODE_SETNAME target: 0 long name, 1 short, 2 frequency, 3 channel
     Mode nameReturn = MODE_SETTINGS; // where the name editor returns on save/cancel


### PR DESCRIPTION
The shared name-editor buffer (25 bytes) is reused by the WiFi/MQTT pages where editMax() allows 63 chars. Long passwords/addresses overran it and saved truncated to 24 chars — WiFi that won't join, MQTT stuck "connecting…". Buffer now sized for the longest field, plus a clamp so limits can't outrun it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)