### PR TITLE
Keep the store listing in the repo, and lead with what removes the objection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,4 +123,5 @@ jobs:
           python scripts/m5burner_publish.py \
             --email "$M5B_EMAIL" --password "$M5B_PWD" \
             --version "${GITHUB_REF_NAME#v}" \
-            --bin meshtastic-adv-cardputer-adv-merged.bin
+            --bin meshtastic-adv-cardputer-adv-merged.bin \
+            --description docs/m5burner-card.txt

--- a/docs/m5burner-card.txt
+++ b/docs/m5burner-card.txt
@@ -1,0 +1,17 @@
+Keyboard-first Meshtastic client for the M5Stack Cardputer ADV — message the mesh right from the keyboard, no phone needed.
+
+• Works with or without a LoRa cap: pair over Bluetooth with any stock Meshtastic node and use its radio
+• Type-to-search contacts, full on-device chat with delivery status
+• Cyrillic + full Unicode (CJK, Arabic, Greek…) via a bundled font partition
+• Emoji palette, reactions, replies
+• On-device settings: region, channels, WiFi/MQTT, LoRa role/hops/power, remote node admin
+
+Installs complete from here — firmware and font partition together, nothing to add afterwards.
+
+Actively developed, updated most weeks. Questions and requests are answered:
+https://github.com/anton-vinogradov/meshtastic-adv/discussions
+
+Open source (GPL-3.0): https://github.com/anton-vinogradov/meshtastic-adv
+Web installer (Chrome/Edge): https://anton-vinogradov.github.io/meshtastic-adv/
+
+Unofficial community project. Meshtastic® is a registered trademark of Meshtastic LLC.

--- a/scripts/m5burner_publish.py
+++ b/scripts/m5burner_publish.py
@@ -26,6 +26,8 @@ def main():
     ap.add_argument("--password", required=True)
     ap.add_argument("--version", required=True, help="version string, no leading v")
     ap.add_argument("--bin", required=True, help="merged image to upload")
+    ap.add_argument("--description", help="file whose contents replace the listing text; "
+                                          "omit to keep whatever the account already has")
     args = ap.parse_args()
 
     s = requests.Session()
@@ -49,9 +51,18 @@ def main():
         return
     print(f"found: {fw.get('name')}")
 
+    # The listing text is the only thing a browsing user reads before deciding, and
+    # until now it lived solely in the M5Burner account — edited through their web UI,
+    # reviewed by nobody, and silently copied forward by this script on every release.
+    # Keeping it in the repo makes it reviewable like the rest of the product.
+    description = fw.get("description", "")
+    if args.description:
+        with open(args.description, encoding="utf-8") as f:
+            description = f.read().strip()
+
     data = {
         "name": fw.get("name", ""),
-        "description": fw.get("description", ""),
+        "description": description,
         "category": fw.get("category", ""),
         "author": fw.get("author", ""),
         "version": args.version,


### PR DESCRIPTION
The M5Burner description is what a browsing user reads before deciding whether to try this, and until now it lived only in the M5Burner account — edited through their web UI, reviewed by nobody, and copied forward unchanged by `m5burner_publish.py` on every release. It moves to `docs/m5burner-card.txt`, and the publisher sends it on the next release.

Three edits to the text:

- **Companion mode moves to the top.** It answers "do I need to buy a LoRa cap for this", and a reader without one was quitting before the fourth bullet.
- **Says the install arrives complete** — true as of this week, now that the font partition comes down with the firmware.
- **Says the project is alive, and links the discussions thread.** The `cardputer` category has 607 entries and most are abandoned; the Meshtastic entry ranked above ours has a single version from eleven months ago. Worth stating that this one is not that.