### PR TITLE
Put the device name in the listing title

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,4 +124,5 @@ jobs:
             --email "$M5B_EMAIL" --password "$M5B_PWD" \
             --version "${GITHUB_REF_NAME#v}" \
             --bin meshtastic-adv-cardputer-adv-merged.bin \
-            --description docs/m5burner-card.txt
+            --description docs/m5burner-card.txt \
+            --name "Meshtastic ADV — Cardputer keyboard client"

--- a/scripts/m5burner_publish.py
+++ b/scripts/m5burner_publish.py
@@ -28,6 +28,7 @@ def main():
     ap.add_argument("--bin", required=True, help="merged image to upload")
     ap.add_argument("--description", help="file whose contents replace the listing text; "
                                           "omit to keep whatever the account already has")
+    ap.add_argument("--name", help="listing title; omit to keep the account's own")
     args = ap.parse_args()
 
     s = requests.Session()
@@ -61,7 +62,7 @@ def main():
             description = f.read().strip()
 
     data = {
-        "name": fw.get("name", ""),
+        "name": args.name or fw.get("name", ""),
         "description": description,
         "category": fw.get("category", ""),
         "author": fw.get("author", ""),


### PR DESCRIPTION
Every entry ranked above ours in this niche carries "Cardputer" in its title:

```
18744  Meshtastic For Cardputer-Adv         1 version,  Sep 2025
11246  Meshtastic for Cardputer ADV w/Cap   8 versions, May 2026
 5725  Cardputer Mesh Kit                   1 version,  Apr 2026
  285  Meshtastic ADV                      21 versions, Jul 2026   ← ours
```

Ours omits the word a Cardputer owner is most likely to search for, and leaves the reader to work out which device it is even for.

`Meshtastic ADV — Cardputer keyboard client` keeps the identity, names the device, and says in three words what separates it from the stock build ranked above it.

`m5burner_publish.py` gains `--name` alongside `--description`; both are omitted-means-keep, so the account's own values still win if the flags are not passed.