### PR TITLE
Stop renaming the listing: it silently swallowed a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,5 +124,4 @@ jobs:
             --email "$M5B_EMAIL" --password "$M5B_PWD" \
             --version "${GITHUB_REF_NAME#v}" \
             --bin meshtastic-adv-cardputer-adv-merged.bin \
-            --description docs/m5burner-card.txt \
-            --name "Meshtastic ADV — Cardputer keyboard client"
+            --description docs/m5burner-card.txt

--- a/scripts/m5burner_publish.py
+++ b/scripts/m5burner_publish.py
@@ -28,6 +28,11 @@ def main():
     ap.add_argument("--bin", required=True, help="merged image to upload")
     ap.add_argument("--description", help="file whose contents replace the listing text; "
                                           "omit to keep whatever the account already has")
+    # Do not pass this without testing it first. The upload POST carries no fid, so the
+    # backend appears to locate the entry by name: sending a different one for v0.4.34
+    # returned 200 and did nothing at all — no version added, no rename, no new entry —
+    # and the release silently failed to reach M5Burner. Every earlier publish worked
+    # only because the name was copied forward untouched.
     ap.add_argument("--name", help="listing title; omit to keep the account's own")
     args = ap.parse_args()
 


### PR DESCRIPTION
**v0.4.34 never reached M5Burner.** The publish step logged `upload ok`, then `uploaded version 0.4.34 not found for publishing`, and failed. The catalogue is still on 0.4.33.

The upload POST carries no `fid` — it goes to the collection endpoint with `name`, `description` and the file, so the backend appears to locate the entry by name. Sending a different name matched nothing: no version added, no rename, no new entry, and still a 200 response. All 21 earlier publishes worked precisely because the name was copied forward untouched, which means this path had never been exercised before I used it.

Reverting the `--name` argument from CI. The flag itself stays, with a warning beside it, since the capability is worth having once someone has tested it against something harmless — but a release pipeline that quietly drops releases must not.

`--description` is untested in the same way: previous runs always sent back the value they had just read. It stays in CI, since a failure there is now visible rather than silent, but the next release is the one that proves it.