### PR TITLE
Second screen: pick how the panel is mounted, in one row

### DIFF
--- a/overlay/src/advui/AdvExtDisplay.h
+++ b/overlay/src/advui/AdvExtDisplay.h
@@ -26,10 +26,6 @@
 namespace advui
 {
 
-// 320 wide from a 240-wide canvas: fills the panel edge to edge and leaves a
-// 30 px band above and below the scaled image, which stays black.
-constexpr float kExtZoom = 320.0f / 240.0f;
-
 class AdvExtDisplay : public lgfx::LGFX_Device
 {
     lgfx::Panel_ILI9341 _panel;

--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -149,7 +149,8 @@ constexpr int kNumSettings = 22; // the flat item table: Name..Channel, Role..Re
 // as direct entries); a section lists indices into the flat item table.
 const uint8_t kSecNode[] = {0, 1};                    // Name, Short
 const uint8_t kSecLora[] = {2, 3, 4, 5, 6, 7, 8, 9};  // Region..Rebroadcast
-const uint8_t kSecDevice[] = {10, 16, 18, 19, 13, 20, 21, 17, 15}; // UTC, Clock, Sort, Names, Screen, 2nd screen, GPS, Font (read-only)
+const uint8_t kSecDevice[] = {10, 16, 18, 19, 13, 20, 21, 17, 15}; // UTC, Clock, Sort, Names, Screen, 2nd screen, 2nd rotate, GPS, Font (read-only)
+
 constexpr int kTopCount = 7;                          // Node, LoRa, WiFi, MQTT, Device, Radio, About
 Msg g_msgs[kMaxMsgs];
 int g_msgCount = 0;         // populated slots (grows to kMaxMsgs)
@@ -3801,6 +3802,21 @@ bool AdvUI::applyName()
     return false;
 }
 
+// The Device section is the only one whose contents vary, so its rows are built in one
+// place: the renderer and the key handler must agree on what row 5 is, or Enter opens
+// the wrong setting. Rotation only means anything once a panel is switched on, and it
+// is noise on every device that has none.
+int deviceItems(uint8_t *out)
+{
+    int n = 0;
+    for (uint8_t it : kSecDevice) {
+        if (it == 21 && !(g_radioCompanion && g_extScreen))
+            continue;
+        out[n++] = it;
+    }
+    return n;
+}
+
 // Brings up the external panel. Guarded twice on purpose: the pins it drives are
 // CS 5, RST 3 and DC 6, which are the SX1262's NSS, RST and BUSY. Touching them with
 // a cap fitted would fight the radio for its chip select, so this refuses to run
@@ -4062,8 +4078,10 @@ void AdvUI::drawSettings()
             rowVal[i] = topIsSection[i] ? ">" : vals[topPreview[i]];
         }
     } else {
-        const uint8_t *items = setSection == 0 ? kSecNode : setSection == 1 ? kSecLora : kSecDevice;
-        listCount = setSection == 0 ? (int)sizeof(kSecNode) : setSection == 1 ? (int)sizeof(kSecLora) : (int)sizeof(kSecDevice);
+        uint8_t dev[sizeof(kSecDevice)];
+        const int devCount = deviceItems(dev);
+        const uint8_t *items = setSection == 0 ? kSecNode : setSection == 1 ? kSecLora : dev;
+        listCount = setSection == 0 ? (int)sizeof(kSecNode) : setSection == 1 ? (int)sizeof(kSecLora) : devCount;
         for (int i = 0; i < listCount; i++) {
             rowLabel[i] = labels[items[i]];
             rowVal[i] = vals[items[i]];
@@ -5142,12 +5160,14 @@ void AdvUI::handleKey(char ch)
     }
 
     if (mode == MODE_SETTINGS) {
-        const uint8_t *items = setSection == 0 ? kSecNode : setSection == 1 ? kSecLora : kSecDevice;
+        uint8_t dev[sizeof(kSecDevice)];
+        const int devCount = deviceItems(dev);
+        const uint8_t *items = setSection == 0 ? kSecNode : setSection == 1 ? kSecLora : dev;
         int listCount = setSection < 0    ? kTopCount
                         : setSection == 0 ? (int)sizeof(kSecNode)
                         : setSection == 1 ? (int)sizeof(kSecLora)
                         : setSection == 3 ? 0 // About has no rows to move between
-                                          : (int)sizeof(kSecDevice);
+                                          : devCount;
         if (esc) {
             if (setSection >= 0) { // back to the top level, cursor on the section's row
                 setSel = setSection == 0 ? 0 : setSection == 1 ? 1 : setSection == 3 ? 6 : 4;
@@ -5333,6 +5353,10 @@ void AdvUI::handleKey(char ch)
                     extInit();
                 else
                     extStop();
+                // Turning it off removes the rotation row underneath it: put the cursor
+                // back on a row that still exists.
+                setSel = 0;
+                setScroll = 0;
                 mode = MODE_SETTINGS;
             } else if (pickTarget == 12) { // unicode font from the card: live, both ways
                 if (kFontOpts[pickSel].value)

--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -143,13 +143,13 @@ const char *errName(uint8_t e, bool broadcast)
 constexpr int kMaxMsgs = 32; // shared across all conversations; DMs are protected by the
                              // channel-first eviction (addMsg), not by size, so this stays small
                              // to keep the heap margin — a connected phone + BLE runs it thin
-constexpr int kNumSettings = 22; // the flat item table: Name..Channel, Role..Rebroadcast, UTC, WiFi, MQTT, Screen, Radio, Font, Clock, GPS, Sort, Names, 2nd screen
+constexpr int kNumSettings = 21; // the flat item table: Name..Channel, Role..Rebroadcast, UTC, WiFi, MQTT, Screen, Radio, Font, Clock, GPS, Sort, Names, 2nd screen
 
 // The Settings menu is two-level: the top lists sections (plus WiFi/MQTT/Radio
 // as direct entries); a section lists indices into the flat item table.
 const uint8_t kSecNode[] = {0, 1};                    // Name, Short
 const uint8_t kSecLora[] = {2, 3, 4, 5, 6, 7, 8, 9};  // Region..Rebroadcast
-const uint8_t kSecDevice[] = {10, 16, 18, 19, 13, 20, 21, 17, 15}; // UTC, Clock, Sort, Names, Screen, 2nd screen, 2nd rotate, GPS, Font (read-only)
+const uint8_t kSecDevice[] = {10, 16, 18, 19, 13, 20, 17, 15}; // UTC, Clock, Sort, Names, Screen, 2nd screen, GPS, Font (read-only)
 
 constexpr int kTopCount = 7;                          // Node, LoRa, WiFi, MQTT, Device, Radio, About
 Msg g_msgs[kMaxMsgs];
@@ -345,13 +345,10 @@ uint8_t g_nameShort = 0;
 // Mirror to an external ILI9341 on the EXT header. Off by default and, when off,
 // costs exactly nothing: the driver object is never constructed and pushFrame()
 // returns after the built-in push. Only meaningful in companion mode — see extInit().
-uint8_t g_extScreen = 0;
-// How the panel is mounted is the builder's choice, not ours. The
-// M5PORKCHOP_DualScreen harness uses LovyanGFX rotation 7, but the first panel built
-// against this firmware came out mirrored with it — and a mirrored image is never
-// what anyone wanted. Hence the unmirrored equivalent as the default, with the other
-// three one menu entry away.
-uint8_t g_extRot = 3;
+// 0 = no second panel; otherwise the LovyanGFX rotation it is mounted at. Which one
+// is the builder's business, not ours: the M5PORKCHOP_DualScreen harness wants 7, and
+// the first panel built against this firmware came out mirrored with exactly that.
+uint8_t g_extRot = 0;
 AdvExtDisplay *g_ext = nullptr;
 const char *kUiCfgPath = "/advui_ui.bin";
 int32_t g_screenOffSec = 300; // screen auto-off timeout; 0 = never
@@ -1282,14 +1279,13 @@ const EnumOpt kScreenOpts[] = {{"15 s", 15}, {"30 s", 30}, {"1 min", 60}, {"5 mi
 // rest are single-criterion. Unread stays pinned on top in every mode.
 const EnumOpt kSortOpts[] = {{"Smart", 0}, {"Last heard", 1}, {"Name", 2}, {"Hops", 3}};
 const EnumOpt kNameOpts[] = {{"Long", 0}, {"Short", 1}};
-const EnumOpt kExtOpts[] = {{"Off", 0}, {"On", 1}};
-constexpr int kExtCount = 2;
-// The panel is meant to sit landscape, so only the four landscape orientations are
-// offered: LovyanGFX 1 and 3 are the two ways round, 5 and 7 the same mirrored.
-// Portrait (0/2/4/6) would squeeze our 240x135 frame into a stripe down the middle,
-// so it is not on the menu at all.
-const EnumOpt kRotOpts[] = {{"Normal", 3}, {"Flip", 1}, {"Mirror", 7}, {"Mirror flip", 5}};
-constexpr int kRotCount = 4;
+// One row, not two: nobody wants to switch a panel on and then go hunting for which
+// way up it is. The value is the LovyanGFX rotation, with 0 standing for "no panel" —
+// rotation 0 is portrait, which is never offered, so it is free to mean off. Only
+// landscape orientations are listed: 1 and 3 are the two ways round, 5 and 7 the same
+// mirrored. Portrait would squeeze a 240x135 frame into a stripe down the middle.
+const EnumOpt kExtOpts[] = {{"Off", 0}, {"Normal", 3}, {"Flip", 1}, {"Mirror", 7}, {"Mirror flip", 5}};
+constexpr int kExtCount = 5;
 constexpr int kNameCount = 2;
 // Only offered when there's no font partition: loading from the card costs
 // ~32 KB of heap (see AdvFont.h), enough to cost this board its networking.
@@ -1313,7 +1309,8 @@ void saveUiCfg()
     int8_t b = (int8_t)g_battRest; // -1 when never sampled off-charge
     f.write((uint8_t *)&b, 1);
     f.write(&g_nameShort, 1);
-    f.write(&g_extScreen, 1);
+    uint8_t on = g_extRot ? 1 : 0; // v0.5.0 wrote the pair; keep the shape, derive both
+    f.write(&on, 1);
     f.write(&g_extRot, 1);
     f.close();
 }
@@ -1332,14 +1329,11 @@ void loadUiCfg()
     uint8_t ns = 0;
     if (f.read(&ns, 1) == 1 && ns <= 1)
         g_nameShort = ns;
-    uint8_t es = 0;
-    if (f.read(&es, 1) == 1 && es <= 1)
-        g_extScreen = es;
-    uint8_t er = 3;
-    // Only the landscape rotations; a value the menu can no longer produce is dropped
-    // rather than honoured, so an old file cannot leave the panel stuck in portrait.
-    if (f.read(&er, 1) == 1 && (er == 1 || er == 3 || er == 5 || er == 7))
-        g_extRot = er;
+    uint8_t es = 0, er = 0;
+    const bool haveOn = f.read(&es, 1) == 1;
+    const bool haveRot = f.read(&er, 1) == 1;
+    if (haveOn && es) // a v0.5.0 file says on; take its orientation when the menu still offers it
+        g_extRot = (haveRot && (er == 1 || er == 3 || er == 5 || er == 7)) ? er : 3;
     f.close();
 }
 const EnumOpt kRoleOpts2[] = {{"Client", 0},      {"Client Mute", 1}, {"Client Hidden", 8},
@@ -1386,8 +1380,7 @@ PickList pickListFor(int target)
     case 2: return {kUtcOpts, kUtcCount, "UTC offset"};
     case 10: return {kSortOpts, kSortCount, "Node sort"};
     case 11: return {kNameOpts, kNameCount, "Node names"};
-    case 13: return {kExtOpts, kExtCount, "2nd screen"};
-    case 14: return {kRotOpts, kRotCount, "2nd screen rotation"};
+    case 13: return {kExtOpts, kExtCount, "2nd screen"};  // off, or how it is mounted
     case 12: return {kFontOpts, kFontCount, "Unicode font"};
     case 4: return {kScreenOpts, kScreenCount, "Screen off"};
     case 5: return {kRoleOpts2, kRoleCount, "Role"};
@@ -3802,20 +3795,6 @@ bool AdvUI::applyName()
     return false;
 }
 
-// The Device section is the only one whose contents vary, so its rows are built in one
-// place: the renderer and the key handler must agree on what row 5 is, or Enter opens
-// the wrong setting. Rotation only means anything once a panel is switched on, and it
-// is noise on every device that has none.
-int deviceItems(uint8_t *out)
-{
-    int n = 0;
-    for (uint8_t it : kSecDevice) {
-        if (it == 21 && !(g_radioCompanion && g_extScreen))
-            continue;
-        out[n++] = it;
-    }
-    return n;
-}
 
 // Brings up the external panel. Guarded twice on purpose: the pins it drives are
 // CS 5, RST 3 and DC 6, which are the SX1262's NSS, RST and BUSY. Touching them with
@@ -3823,12 +3802,12 @@ int deviceItems(uint8_t *out)
 // outside companion mode even if the stored flag says otherwise.
 void AdvUI::extInit()
 {
-    if (g_ext || !g_extScreen || !g_radioCompanion)
+    if (g_ext || !g_extRot || !g_radioCompanion)
         return;
     g_ext = new (std::nothrow) AdvExtDisplay();
     if (!g_ext) {
         LOG_WARN("advui: no memory for the second screen");
-        g_extScreen = 0;
+        g_extRot = 0;
         return;
     }
     {
@@ -3964,7 +3943,7 @@ void AdvUI::drawSettings()
                                         "Channel", "Role",     "Hops",   "Power",  "Rebroadcast",
                                         "UTC",     "WiFi",     "MQTT",   "Screen", "Radio",
                                         "Font",    "Clock",    "GPS",    "Sort",  "Names",
-                                        "2nd screen", "2nd rotate"};
+                                        "2nd screen"};
     char vals[kNumSettings][24];
     if (g_radioCompanion) { // rows 0-5 show (and remote-admin edit) the linked node
         meshtastic_NodeInfoLite *me = g_linkMyNode ? nodeByNum(g_linkMyNode) : nullptr;
@@ -4056,8 +4035,7 @@ void AdvUI::drawSettings()
     strcpy(vals[19], kNameOpts[g_nameShort ? 1 : 0].name);
     // Says why it is unavailable rather than silently showing "Off": these pins belong
     // to the radio, so the answer depends on which radio mode the node is running.
-    strcpy(vals[20], !g_radioCompanion ? "companion only" : (g_extScreen ? "On" : "Off"));
-    strcpy(vals[21], optName(kRotOpts, kRotCount, (int)g_extRot));
+    strcpy(vals[20], !g_radioCompanion ? "companion only" : optName(kExtOpts, kExtCount, (int)g_extRot));
 
     // What the current level shows: top = sections + direct entries (with a
     // representative value as the preview), sub = the section's flat items.
@@ -4078,10 +4056,8 @@ void AdvUI::drawSettings()
             rowVal[i] = topIsSection[i] ? ">" : vals[topPreview[i]];
         }
     } else {
-        uint8_t dev[sizeof(kSecDevice)];
-        const int devCount = deviceItems(dev);
-        const uint8_t *items = setSection == 0 ? kSecNode : setSection == 1 ? kSecLora : dev;
-        listCount = setSection == 0 ? (int)sizeof(kSecNode) : setSection == 1 ? (int)sizeof(kSecLora) : devCount;
+        const uint8_t *items = setSection == 0 ? kSecNode : setSection == 1 ? kSecLora : kSecDevice;
+        listCount = setSection == 0 ? (int)sizeof(kSecNode) : setSection == 1 ? (int)sizeof(kSecLora) : (int)sizeof(kSecDevice);
         for (int i = 0; i < listCount; i++) {
             rowLabel[i] = labels[items[i]];
             rowVal[i] = vals[items[i]];
@@ -5037,20 +5013,13 @@ void AdvUI::openSetting(int item)
         pickSel = strcmp(sdFontState(), "sd") == 0 ? 1 : 0;
         pickScroll = 0;
         mode = MODE_PICKLIST;
-    } else if (item == 21) { // second screen rotation -> picker, companion only
-        if (!g_radioCompanion)
-            return;
-        pickTarget = 14;
-        pickSel = optIndex(kRotOpts, kRotCount, (int)g_extRot);
-        pickScroll = 0;
-        mode = MODE_PICKLIST;
     } else if (item == 20) { // second screen -> picker, companion only
         // Refuse outright rather than let the picker set a flag that extInit() will
         // ignore: with a cap fitted, CS/RST/DC are the radio's NSS/RST/BUSY.
         if (!g_radioCompanion)
             return;
         pickTarget = 13;
-        pickSel = g_extScreen ? 1 : 0;
+        pickSel = optIndex(kExtOpts, kExtCount, (int)g_extRot);
         pickScroll = 0;
         mode = MODE_PICKLIST;
     } else if (item == 19) { // node-list name style -> picker
@@ -5160,14 +5129,12 @@ void AdvUI::handleKey(char ch)
     }
 
     if (mode == MODE_SETTINGS) {
-        uint8_t dev[sizeof(kSecDevice)];
-        const int devCount = deviceItems(dev);
-        const uint8_t *items = setSection == 0 ? kSecNode : setSection == 1 ? kSecLora : dev;
+        const uint8_t *items = setSection == 0 ? kSecNode : setSection == 1 ? kSecLora : kSecDevice;
         int listCount = setSection < 0    ? kTopCount
                         : setSection == 0 ? (int)sizeof(kSecNode)
                         : setSection == 1 ? (int)sizeof(kSecLora)
                         : setSection == 3 ? 0 // About has no rows to move between
-                                          : devCount;
+                                          : (int)sizeof(kSecDevice);
         if (esc) {
             if (setSection >= 0) { // back to the top level, cursor on the section's row
                 setSel = setSection == 0 ? 0 : setSection == 1 ? 1 : setSection == 3 ? 6 : 4;
@@ -5337,26 +5304,18 @@ void AdvUI::handleKey(char ch)
                 g_nameShort = (uint8_t)kNameOpts[pickSel].value;
                 saveUiCfg();
                 mode = MODE_SETTINGS;
-            } else if (pickTarget == 14) { // panel orientation: applied live, redraw follows
-                g_extRot = (uint8_t)kRotOpts[pickSel].value;
+            } else if (pickTarget == 13) { // second screen: off, or mounted this way round
+                g_extRot = (uint8_t)kExtOpts[pickSel].value;
                 saveUiCfg();
-                if (g_ext) {
+                if (!g_extRot) {
+                    extStop();
+                } else if (g_ext) { // already up: just turn the picture round
                     concurrency::LockGuard guard(spiLock);
                     g_ext->setRotation(g_extRot);
-                    g_ext->fillScreen(0); // the letterbox bands move with the rotation
-                }
-                mode = MODE_SETTINGS;
-            } else if (pickTarget == 13) { // second screen: brought up or torn down live
-                g_extScreen = (uint8_t)kExtOpts[pickSel].value;
-                saveUiCfg();
-                if (g_extScreen)
+                    g_ext->fillScreen(0); // the letterbox bands move with it
+                } else {
                     extInit();
-                else
-                    extStop();
-                // Turning it off removes the rotation row underneath it: put the cursor
-                // back on a row that still exists.
-                setSel = 0;
-                setScroll = 0;
+                }
                 mode = MODE_SETTINGS;
             } else if (pickTarget == 12) { // unicode font from the card: live, both ways
                 if (kFontOpts[pickSel].value)

--- a/overlay/src/advui/AdvUI.cpp
+++ b/overlay/src/advui/AdvUI.cpp
@@ -143,13 +143,13 @@ const char *errName(uint8_t e, bool broadcast)
 constexpr int kMaxMsgs = 32; // shared across all conversations; DMs are protected by the
                              // channel-first eviction (addMsg), not by size, so this stays small
                              // to keep the heap margin — a connected phone + BLE runs it thin
-constexpr int kNumSettings = 21; // the flat item table: Name..Channel, Role..Rebroadcast, UTC, WiFi, MQTT, Screen, Radio, Font, Clock, GPS, Sort, Names, 2nd screen
+constexpr int kNumSettings = 22; // the flat item table: Name..Channel, Role..Rebroadcast, UTC, WiFi, MQTT, Screen, Radio, Font, Clock, GPS, Sort, Names, 2nd screen
 
 // The Settings menu is two-level: the top lists sections (plus WiFi/MQTT/Radio
 // as direct entries); a section lists indices into the flat item table.
 const uint8_t kSecNode[] = {0, 1};                    // Name, Short
 const uint8_t kSecLora[] = {2, 3, 4, 5, 6, 7, 8, 9};  // Region..Rebroadcast
-const uint8_t kSecDevice[] = {10, 16, 18, 19, 13, 20, 17, 15}; // UTC, Clock, Sort, Names, Screen, 2nd screen, GPS, Font (read-only)
+const uint8_t kSecDevice[] = {10, 16, 18, 19, 13, 20, 21, 17, 15}; // UTC, Clock, Sort, Names, Screen, 2nd screen, GPS, Font (read-only)
 constexpr int kTopCount = 7;                          // Node, LoRa, WiFi, MQTT, Device, Radio, About
 Msg g_msgs[kMaxMsgs];
 int g_msgCount = 0;         // populated slots (grows to kMaxMsgs)
@@ -345,6 +345,12 @@ uint8_t g_nameShort = 0;
 // costs exactly nothing: the driver object is never constructed and pushFrame()
 // returns after the built-in push. Only meaningful in companion mode — see extInit().
 uint8_t g_extScreen = 0;
+// How the panel is mounted is the builder's choice, not ours. The
+// M5PORKCHOP_DualScreen harness uses LovyanGFX rotation 7, but the first panel built
+// against this firmware came out mirrored with it — and a mirrored image is never
+// what anyone wanted. Hence the unmirrored equivalent as the default, with the other
+// three one menu entry away.
+uint8_t g_extRot = 3;
 AdvExtDisplay *g_ext = nullptr;
 const char *kUiCfgPath = "/advui_ui.bin";
 int32_t g_screenOffSec = 300; // screen auto-off timeout; 0 = never
@@ -1277,6 +1283,12 @@ const EnumOpt kSortOpts[] = {{"Smart", 0}, {"Last heard", 1}, {"Name", 2}, {"Hop
 const EnumOpt kNameOpts[] = {{"Long", 0}, {"Short", 1}};
 const EnumOpt kExtOpts[] = {{"Off", 0}, {"On", 1}};
 constexpr int kExtCount = 2;
+// The panel is meant to sit landscape, so only the four landscape orientations are
+// offered: LovyanGFX 1 and 3 are the two ways round, 5 and 7 the same mirrored.
+// Portrait (0/2/4/6) would squeeze our 240x135 frame into a stripe down the middle,
+// so it is not on the menu at all.
+const EnumOpt kRotOpts[] = {{"Normal", 3}, {"Flip", 1}, {"Mirror", 7}, {"Mirror flip", 5}};
+constexpr int kRotCount = 4;
 constexpr int kNameCount = 2;
 // Only offered when there's no font partition: loading from the card costs
 // ~32 KB of heap (see AdvFont.h), enough to cost this board its networking.
@@ -1301,6 +1313,7 @@ void saveUiCfg()
     f.write((uint8_t *)&b, 1);
     f.write(&g_nameShort, 1);
     f.write(&g_extScreen, 1);
+    f.write(&g_extRot, 1);
     f.close();
 }
 
@@ -1321,6 +1334,11 @@ void loadUiCfg()
     uint8_t es = 0;
     if (f.read(&es, 1) == 1 && es <= 1)
         g_extScreen = es;
+    uint8_t er = 3;
+    // Only the landscape rotations; a value the menu can no longer produce is dropped
+    // rather than honoured, so an old file cannot leave the panel stuck in portrait.
+    if (f.read(&er, 1) == 1 && (er == 1 || er == 3 || er == 5 || er == 7))
+        g_extRot = er;
     f.close();
 }
 const EnumOpt kRoleOpts2[] = {{"Client", 0},      {"Client Mute", 1}, {"Client Hidden", 8},
@@ -1368,6 +1386,7 @@ PickList pickListFor(int target)
     case 10: return {kSortOpts, kSortCount, "Node sort"};
     case 11: return {kNameOpts, kNameCount, "Node names"};
     case 13: return {kExtOpts, kExtCount, "2nd screen"};
+    case 14: return {kRotOpts, kRotCount, "2nd screen rotation"};
     case 12: return {kFontOpts, kFontCount, "Unicode font"};
     case 4: return {kScreenOpts, kScreenCount, "Screen off"};
     case 5: return {kRoleOpts2, kRoleCount, "Role"};
@@ -3799,7 +3818,7 @@ void AdvUI::extInit()
     {
         concurrency::LockGuard guard(spiLock); // the SD card is on this bus too
         g_ext->init();
-        g_ext->setRotation(7); // 240x320 panel driven as 320x240 landscape
+        g_ext->setRotation(g_extRot); // however the builder mounted it
         g_ext->fillScreen(0);
     }
     canvas.setPivot(120, 67); // centre of our frame, the anchor pushFrame() scales about
@@ -3830,8 +3849,14 @@ void AdvUI::pushFrame()
     canvas.pushSprite(0, 0);
     if (!g_ext)
         return;
+    // Fit rather than a fixed factor: rotation changes which way round the panel is,
+    // and a 90-degree mount turns 320x240 into 240x320. Scale to whichever axis runs
+    // out first and centre it; the remainder stays black.
+    const float zx = (float)g_ext->width() / 240.0f;
+    const float zy = (float)g_ext->height() / 135.0f;
+    const float z = zx < zy ? zx : zy;
     concurrency::LockGuard guard(spiLock);
-    canvas.pushRotateZoom(g_ext, 160, 120, 0.0f, kExtZoom, kExtZoom);
+    canvas.pushRotateZoom(g_ext, g_ext->width() / 2.0f, g_ext->height() / 2.0f, 0.0f, z, z);
 }
 
 // Who made this, what it is built on, and where to go with a question. The font
@@ -3923,7 +3948,7 @@ void AdvUI::drawSettings()
                                         "Channel", "Role",     "Hops",   "Power",  "Rebroadcast",
                                         "UTC",     "WiFi",     "MQTT",   "Screen", "Radio",
                                         "Font",    "Clock",    "GPS",    "Sort",  "Names",
-                                        "2nd screen"};
+                                        "2nd screen", "2nd rotate"};
     char vals[kNumSettings][24];
     if (g_radioCompanion) { // rows 0-5 show (and remote-admin edit) the linked node
         meshtastic_NodeInfoLite *me = g_linkMyNode ? nodeByNum(g_linkMyNode) : nullptr;
@@ -4016,6 +4041,7 @@ void AdvUI::drawSettings()
     // Says why it is unavailable rather than silently showing "Off": these pins belong
     // to the radio, so the answer depends on which radio mode the node is running.
     strcpy(vals[20], !g_radioCompanion ? "companion only" : (g_extScreen ? "On" : "Off"));
+    strcpy(vals[21], optName(kRotOpts, kRotCount, (int)g_extRot));
 
     // What the current level shows: top = sections + direct entries (with a
     // representative value as the preview), sub = the section's flat items.
@@ -4993,6 +5019,13 @@ void AdvUI::openSetting(int item)
         pickSel = strcmp(sdFontState(), "sd") == 0 ? 1 : 0;
         pickScroll = 0;
         mode = MODE_PICKLIST;
+    } else if (item == 21) { // second screen rotation -> picker, companion only
+        if (!g_radioCompanion)
+            return;
+        pickTarget = 14;
+        pickSel = optIndex(kRotOpts, kRotCount, (int)g_extRot);
+        pickScroll = 0;
+        mode = MODE_PICKLIST;
     } else if (item == 20) { // second screen -> picker, companion only
         // Refuse outright rather than let the picker set a flag that extInit() will
         // ignore: with a cap fitted, CS/RST/DC are the radio's NSS/RST/BUSY.
@@ -5283,6 +5316,15 @@ void AdvUI::handleKey(char ch)
             } else if (pickTarget == 11) { // long vs short names: live, same tiny file
                 g_nameShort = (uint8_t)kNameOpts[pickSel].value;
                 saveUiCfg();
+                mode = MODE_SETTINGS;
+            } else if (pickTarget == 14) { // panel orientation: applied live, redraw follows
+                g_extRot = (uint8_t)kRotOpts[pickSel].value;
+                saveUiCfg();
+                if (g_ext) {
+                    concurrency::LockGuard guard(spiLock);
+                    g_ext->setRotation(g_extRot);
+                    g_ext->fillScreen(0); // the letterbox bands move with the rotation
+                }
                 mode = MODE_SETTINGS;
             } else if (pickTarget == 13) { // second screen: brought up or torn down live
                 g_extScreen = (uint8_t)kExtOpts[pickSel].value;


### PR DESCRIPTION
The first panel built against this firmware lit up on the first try — and came out **mirrored**: readable, but back to front.

That is not a wiring fault or a driver bug. LovyanGFX rotation 7 is what the M5PORKCHOP_DualScreen harness uses, and a panel glued in the other orientation needs a different one. Every one of these is hand-built, so the firmware cannot know which — the person holding it can.

### One row, not two

**Settings → Device → 2nd screen** is now a single list: `Off`, `Normal`, `Flip`, `Mirror`, `Mirror flip`. Picking an orientation is what turns the panel on — switching it on and then hunting for which way up it goes is two decisions where the user has one.

The state collapses with it: one byte holds the LovyanGFX rotation, and `0` means no panel. Rotation 0 is portrait, never offered for a 240x135 frame on a 240-wide panel, so it was free to mean off. Portrait orientations are absent for the same reason — they would squeeze the frame into a stripe down the middle.

Changing orientation while the panel is up just turns the picture round and clears it (the letterbox bands move with the rotation); no re-init.

Configs written by v0.5.0 still load — they carry the on-flag and the rotation as a pair, and an orientation the menu no longer offers falls back to `Normal`.

### Also fixes a constant that was right by luck

Scaling was `320/240`, which assumed the panel stays mounted the way the fork mounts it. A 90-degree turn makes the same panel 240x320 and that constant would have pushed the frame off the glass — so the rotation setting would have worked only halfway. `pushFrame()` now fits to whichever axis runs out first and centres the remainder.

RAM unchanged at 56.4 %; flash 2,538,791 → 2,539,383.